### PR TITLE
Fix: use websock instead of news

### DIFF
--- a/nim.cfg
+++ b/nim.cfg
@@ -1,2 +1,3 @@
 -d:"chronicles_log_level=INFO"
+-d:"json_rpc_websocket_package=websock"
 --warning[LockLevel]:off


### PR DESCRIPTION
The default was changed to news in the json_rpc
library, and broke communication with hardhat.