### PR TITLE
fix: pending blocks may not contains block hash

### DIFF
--- a/ethers/provider.nim
+++ b/ethers/provider.nim
@@ -46,7 +46,7 @@ type
   Block* = object
     number*: ?UInt256
     timestamp*: UInt256
-    hash*: array[32, byte]
+    hash*: ?array[32, byte]
 
 const EthersDefaultConfirmations* {.intdefine.} = 12
 const EthersReceiptTimeoutBlks* {.intdefine.} = 50 # in blocks

--- a/testmodule/testJsonRpcProvider.nim
+++ b/testmodule/testJsonRpcProvider.nim
@@ -127,6 +127,20 @@ suite "JsonRpcProvider":
     check blk.number.isSome
     check blk.number.get.isZero
 
+  test "Conversion: missing block hash in Block isNone":
+
+    var blkJson = %*{
+      "subscription": "0x20",
+      "result":{
+        "number": "0x1",
+        "hash": newJNull(),
+        "timestamp": "0x6285c293"
+      }
+    }
+
+    var blk = Block.fromJson(blkJson["result"])
+    check blk.hash.isNone
+
   test "Conversion: missing block number in TransactionReceipt isNone":
 
     var txReceiptJson = %*{


### PR DESCRIPTION
Pending blocks may not contain a block hash and therefore Block.hash should be optional.