### PR TITLE
Polling subscriptions for http urls

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -90,6 +90,12 @@ await writableToken.transfer(accounts[7], 42.u256)
 
 Which transfers 42 tokens from account 3 to account 7
 
+And lastly, don't forget to close the provider when you're done:
+
+```
+await provider.close()
+```
+
 Events
 ------
 

--- a/Readme.md
+++ b/Readme.md
@@ -140,9 +140,6 @@ When you're no longer interested in these events, you can unsubscribe:
 await subscription.unsubscribe()
 ```
 
-Subscriptions are currently only supported when using a JSON RPC provider that
-is created with a websockets URL such as `ws://localhost:8545`.
-
 Utilities
 ---------
 

--- a/ethers.nimble
+++ b/ethers.nimble
@@ -5,7 +5,7 @@ license = "MIT"
 
 requires "nim >= 1.6.0"
 requires "chronos >= 3.0.0 & < 4.0.0"
-requires "contractabi >= 0.4.6 & < 0.5.0"
+requires "contractabi >= 0.5.0 & < 0.6.0"
 requires "questionable >= 0.10.2 & < 0.11.0"
 requires "upraises >= 0.1.0 & < 0.2.0"
 requires "json_rpc"

--- a/ethers/provider.nim
+++ b/ethers/provider.nim
@@ -208,3 +208,6 @@ proc confirm*(tx: Future[?TransactionResponse],
     )
 
   return await txResp.confirm(wantedConfirms, timeoutInBlocks)
+
+method close*(provider: Provider) {.async, base.} =
+  discard

--- a/ethers/providers/jsonrpc.nim
+++ b/ethers/providers/jsonrpc.nim
@@ -47,11 +47,14 @@ template convertError(body) =
 # Provider
 
 const defaultUrl = "http://localhost:8545"
+const defaultPollingInterval = 4.seconds
 
 proc jsonHeaders: seq[(string, string)] =
   @[("Content-Type", "application/json")]
 
-proc new*(_: type JsonRpcProvider, url=defaultUrl): JsonRpcProvider =
+proc new*(_: type JsonRpcProvider,
+          url=defaultUrl,
+          pollingInterval=defaultPollingInterval): JsonRpcProvider =
   var initialized: Future[void]
   var client: RpcClient
   var subscriptions: JsonRpcSubscriptions
@@ -67,7 +70,8 @@ proc new*(_: type JsonRpcProvider, url=defaultUrl): JsonRpcProvider =
       let http = newRpcHttpClient(getHeaders = jsonHeaders)
       await http.connect(url)
       client = http
-      subscriptions = JsonRpcSubscriptions.new(http)
+      subscriptions = JsonRpcSubscriptions.new(http,
+                                               pollingInterval = pollingInterval)
 
   proc awaitClient: Future[RpcClient] {.async.} =
     await initialized

--- a/ethers/providers/jsonrpc.nim
+++ b/ethers/providers/jsonrpc.nim
@@ -177,6 +177,13 @@ method subscribe*(provider: JsonRpcProvider,
     let subscriptions = await provider.subscriptions
     return await subscriptions.subscribeBlocks(onBlock)
 
+method close*(provider: JsonRpcProvider) {.async.} =
+  convertError:
+    let client = await provider.client
+    let subscriptions = await provider.subscriptions
+    await subscriptions.close()
+    await client.close()
+
 # Signer
 
 method provider*(signer: JsonRpcSigner): Provider =

--- a/ethers/providers/jsonrpc/looping.nim
+++ b/ethers/providers/jsonrpc/looping.nim
@@ -1,0 +1,6 @@
+template untilCancelled*(body) =
+  try:
+    while true:
+      body
+  except CancelledError:
+    raise

--- a/ethers/providers/jsonrpc/signatures.nim
+++ b/ethers/providers/jsonrpc/signatures.nim
@@ -4,6 +4,7 @@ proc eth_blockNumber: UInt256
 proc eth_call(transaction: Transaction, blockTag: BlockTag): seq[byte]
 proc eth_gasPrice(): UInt256
 proc eth_getBlockByNumber(blockTag: BlockTag, includeTransactions: bool): ?Block
+proc eth_getBlockByHash(hash: BlockHash, includeTransactions: bool): ?Block
 proc eth_getTransactionCount(address: Address, blockTag: BlockTag): UInt256
 proc eth_estimateGas(transaction: Transaction): UInt256
 proc eth_chainId(): UInt256
@@ -14,3 +15,6 @@ proc eth_sign(account: Address, message: seq[byte]): seq[byte]
 proc eth_subscribe(name: string, filter: Filter): JsonNode
 proc eth_subscribe(name: string): JsonNode
 proc eth_unsubscribe(id: JsonNode): bool
+proc eth_newBlockFilter(): JsonNode
+proc eth_getFilterChanges(id: JsonNode): JsonNode
+proc eth_uninstallFilter(id: JsonNode): bool

--- a/ethers/providers/jsonrpc/signatures.nim
+++ b/ethers/providers/jsonrpc/signatures.nim
@@ -16,5 +16,6 @@ proc eth_subscribe(name: string, filter: Filter): JsonNode
 proc eth_subscribe(name: string): JsonNode
 proc eth_unsubscribe(id: JsonNode): bool
 proc eth_newBlockFilter(): JsonNode
+proc eth_newFilter(filter: Filter): JsonNode
 proc eth_getFilterChanges(id: JsonNode): JsonNode
 proc eth_uninstallFilter(id: JsonNode): bool

--- a/ethers/providers/jsonrpc/subscriptions.nim
+++ b/ethers/providers/jsonrpc/subscriptions.nim
@@ -105,8 +105,14 @@ proc new*(_: type JsonRpcSubscriptions,
 
   let subscriptions = PollingSubscriptions(client: client)
 
+  proc getChanges(id: JsonNode): Future[JsonNode] {.async.} =
+    try:
+      return await subscriptions.client.eth_getFilterChanges(id)
+    except CatchableError:
+      return newJArray()
+
   proc poll(id: JsonNode) {.async.} =
-    for change in await subscriptions.client.eth_getFilterChanges(id):
+    for change in await getChanges(id):
       if callback =? subscriptions.getCallback(id):
         callback(id, change)
 

--- a/ethers/providers/jsonrpc/subscriptions.nim
+++ b/ethers/providers/jsonrpc/subscriptions.nim
@@ -35,6 +35,11 @@ method unsubscribe(subscriptions: JsonRpcSubscriptions,
                   {.async, base.} =
   raiseAssert "not implemented"
 
+method close*(subscriptions: JsonRpcSubscriptions) {.async.} =
+  let ids = toSeq subscriptions.callbacks.keys
+  for id in ids:
+    await subscriptions.unsubscribe(id)
+
 method unsubscribe(subscription: JsonRpcSubscription) {.async.} =
   let subscriptions = subscription.subscriptions
   let id = subscription.id

--- a/ethers/providers/jsonrpc/subscriptions.nim
+++ b/ethers/providers/jsonrpc/subscriptions.nim
@@ -6,6 +6,7 @@ import ../../basics
 import ../../provider
 import ./rpccalls
 import ./conversions
+import ./looping
 
 type
   JsonRpcSubscriptions* = ref object of RootObj
@@ -110,13 +111,10 @@ proc new*(_: type JsonRpcSubscriptions,
         callback(id, change)
 
   proc poll {.async.} =
-    try:
-      while true:
-        for id in toSeq subscriptions.callbacks.keys:
-          await poll(id)
-        await sleepAsync(pollingInterval)
-    except CancelledError:
-      raise
+    untilCancelled:
+      for id in toSeq subscriptions.callbacks.keys:
+        await poll(id)
+      await sleepAsync(pollingInterval)
 
   asyncSpawn poll()
 

--- a/ethers/providers/jsonrpc/subscriptions.nim
+++ b/ethers/providers/jsonrpc/subscriptions.nim
@@ -99,7 +99,8 @@ type
   PollingSubscriptions = ref object of JsonRpcSubscriptions
 
 proc new*(_: type JsonRpcSubscriptions,
-          client: RpcHttpClient): JsonRpcSubscriptions =
+          client: RpcHttpClient,
+          pollingInterval = 4.seconds): JsonRpcSubscriptions =
 
   let subscriptions = PollingSubscriptions(client: client)
 
@@ -113,7 +114,7 @@ proc new*(_: type JsonRpcSubscriptions,
       while true:
         for id in toSeq subscriptions.callbacks.keys:
           await poll(id)
-        await sleepAsync(1.seconds)
+        await sleepAsync(pollingInterval)
     except CancelledError:
       raise
 

--- a/ethers/providers/jsonrpc/subscriptions.nim
+++ b/ethers/providers/jsonrpc/subscriptions.nim
@@ -132,8 +132,11 @@ method subscribeBlocks(subscriptions: PollingSubscriptions,
                       {.async.} =
 
   proc getBlock(hash: BlockHash) {.async.} =
-    if blck =? (await subscriptions.client.eth_getBlockByHash(hash, false)):
-      await onBlock(blck)
+    try:
+      if blck =? (await subscriptions.client.eth_getBlockByHash(hash, false)):
+        await onBlock(blck)
+    except CatchableError:
+      discard
 
   proc callback(id, change: JsonNode) =
     if hash =? BlockHash.fromJson(change).catch:

--- a/ethers/providers/jsonrpc/subscriptions.nim
+++ b/ethers/providers/jsonrpc/subscriptions.nim
@@ -1,0 +1,100 @@
+import std/tables
+import pkg/chronos
+import pkg/json_rpc/rpcclient
+import ../../basics
+import ../../provider
+import ./rpccalls
+import ./conversions
+
+type
+  JsonRpcSubscriptions* = ref object of RootObj
+    client: RpcClient
+    callbacks: Table[JsonNode, SubscriptionCallback]
+  JsonRpcSubscription = ref object of Subscription
+    subscriptions: JsonRpcSubscriptions
+    id: JsonNode
+  SubscriptionCallback = proc(id, arguments: JsonNode) {.gcsafe, upraises:[].}
+
+method subscribeBlocks*(subscriptions: JsonRpcSubscriptions,
+                        onBlock: BlockHandler):
+                       Future[JsonRpcSubscription]
+                       {.async, base.} =
+  raiseAssert "not implemented"
+
+method subscribeLogs*(subscriptions: JsonRpcSubscriptions,
+                      filter: Filter,
+                      onLog: LogHandler):
+                     Future[JsonRpcSubscription]
+                     {.async, base.} =
+  raiseAssert "not implemented"
+
+method unsubscribe(subscriptions: JsonRpcSubscriptions,
+                   id: JsonNode)
+                  {.async, base.} =
+  raiseAssert "not implemented"
+
+method unsubscribe(subscription: JsonRpcSubscription) {.async.} =
+  await subscription.subscriptions.unsubscribe(subscription.id)
+
+proc getCallback(subscriptions: JsonRpcSubscriptions,
+                 id: JsonNode): ?SubscriptionCallback =
+  try:
+    if subscriptions.callbacks.hasKey(id):
+      subscriptions.callbacks[id].some
+    else:
+      SubscriptionCallback.none
+  except Exception:
+    SubscriptionCallback.none
+
+# Web sockets
+
+type
+  WebSocketSubscriptions = ref object of JsonRpcSubscriptions
+
+method subscribeBlocks(subscriptions: WebSocketSubscriptions,
+                       onBlock: BlockHandler):
+                       Future[JsonRpcSubscription]
+                       {.async.} =
+  proc callback(id, arguments: JsonNode) =
+    if blck =? Block.fromJson(arguments["result"]).catch:
+      asyncSpawn onBlock(blck)
+  let id = await subscriptions.client.eth_subscribe("newHeads")
+  subscriptions.callbacks[id] = callback
+  return JsonRpcSubscription(subscriptions: subscriptions, id: id)
+
+method subscribeLogs(subscriptions: WebSocketSubscriptions,
+                     filter: Filter,
+                     onLog: LogHandler):
+                    Future[JsonRpcSubscription]
+                    {.async.} =
+  proc callback(id, arguments: JsonNode) =
+    if log =? Log.fromJson(arguments["result"]).catch:
+      onLog(log)
+  let id = await subscriptions.client.eth_subscribe("logs", filter)
+  subscriptions.callbacks[id] = callback
+  return JsonRpcSubscription(subscriptions: subscriptions, id: id)
+
+method unsubscribe(subscriptions: WebSocketSubscriptions,
+                   id: JsonNode)
+                  {.async.} =
+  subscriptions.callbacks.del(id)
+  discard await subscriptions.client.eth_unsubscribe(id)
+
+proc new*(_: type JsonRpcSubscriptions,
+          client: RpcWebSocketClient): JsonRpcSubscriptions =
+  let subscriptions = WebSocketSubscriptions(client: client)
+  proc subscriptionHandler(arguments: JsonNode) {.upraises:[].} =
+    if id =? arguments["subscription"].catch and
+       callback =? subscriptions.getCallback(id):
+      callback(id, arguments)
+  client.setMethodHandler("eth_subscription", subscriptionHandler)
+  subscriptions
+
+# Polling
+
+type
+  PollingSubscriptions = ref object of JsonRpcSubscriptions
+
+func new*(_: type JsonRpcSubscriptions,
+          client: RpcHttpClient): JsonRpcSubscriptions =
+  PollingSubscriptions(client: client)

--- a/ethers/providers/jsonrpc/subscriptions.nim
+++ b/ethers/providers/jsonrpc/subscriptions.nim
@@ -146,6 +146,20 @@ method subscribeBlocks(subscriptions: PollingSubscriptions,
   subscriptions.callbacks[id] = callback
   return JsonRpcSubscription(subscriptions: subscriptions, id: id)
 
+method subscribeLogs(subscriptions: PollingSubscriptions,
+                     filter: Filter,
+                     onLog: LogHandler):
+                    Future[JsonRpcSubscription]
+                    {.async.} =
+
+  proc callback(id, change: JsonNode) =
+    if log =? Log.fromJson(change).catch:
+      onLog(log)
+
+  let id = await subscriptions.client.eth_newFilter(filter)
+  subscriptions.callbacks[id] = callback
+  return JsonRpcSubscription(subscriptions: subscriptions, id: id)
+
 method unsubscribe(subscriptions: PollingSubscriptions,
                    id: JsonNode)
                   {.async.} =

--- a/testmodule/providers/jsonrpc/testJsonRpcProvider.nim
+++ b/testmodule/providers/jsonrpc/testJsonRpcProvider.nim
@@ -42,6 +42,7 @@ for url in ["ws://localhost:8545", "http://localhost:8545"]:
 
     test "subscribes to new blocks":
       let oldBlock = !await provider.getBlock(BlockTag.latest)
+      discard await provider.send("evm_mine")
       var newBlock: Block
       let blockHandler = proc(blck: Block) {.async.} = newBlock = blck
       let subscription = await provider.subscribe(blockHandler)

--- a/testmodule/providers/jsonrpc/testJsonRpcProvider.nim
+++ b/testmodule/providers/jsonrpc/testJsonRpcProvider.nim
@@ -7,126 +7,123 @@ import pkg/stew/byteutils
 import ../../examples
 import ../../miner
 
-suite "JsonRpcProvider":
+for url in ["ws://localhost:8545", "http://localhost:8545"]:
 
-  var provider: JsonRpcProvider
+  suite "JsonRpcProvider (" & url & ")":
 
-  setup:
-    provider = JsonRpcProvider.new("ws://localhost:8545")
+    var provider: JsonRpcProvider
 
-  test "can be instantiated with a default URL":
-    discard JsonRpcProvider.new()
+    setup:
+      provider = JsonRpcProvider.new(url)
 
-  test "can be instantiated with an HTTP URL":
-    discard JsonRpcProvider.new("http://localhost:8545")
+    test "can be instantiated with a default URL":
+      discard JsonRpcProvider.new()
 
-  test "can be instantiated with a websocket URL":
-    discard JsonRpcProvider.new("ws://localhost:8545")
+    test "lists all accounts":
+      let accounts = await provider.listAccounts()
+      check accounts.len > 0
 
-  test "lists all accounts":
-    let accounts = await provider.listAccounts()
-    check accounts.len > 0
+    test "sends raw messages to the provider":
+      let response = await provider.send("evm_mine")
+      check response == %"0x0"
 
-  test "sends raw messages to the provider":
-    let response = await provider.send("evm_mine")
-    check response == %"0x0"
+    test "returns block number":
+      let blocknumber1 = await provider.getBlockNumber()
+      discard await provider.send("evm_mine")
+      let blocknumber2 = await provider.getBlockNumber()
+      check blocknumber2 > blocknumber1
 
-  test "returns block number":
-    let blocknumber1 = await provider.getBlockNumber()
-    discard await provider.send("evm_mine")
-    let blocknumber2 = await provider.getBlockNumber()
-    check blocknumber2 > blocknumber1
+    test "returns block":
+      let block1 = !await provider.getBlock(BlockTag.earliest)
+      let block2 = !await provider.getBlock(BlockTag.latest)
+      check block1.hash != block2.hash
+      check !block1.number < !block2.number
+      check block1.timestamp < block2.timestamp
 
-  test "returns block":
-    let block1 = !await provider.getBlock(BlockTag.earliest)
-    let block2 = !await provider.getBlock(BlockTag.latest)
-    check block1.hash != block2.hash
-    check !block1.number < !block2.number
-    check block1.timestamp < block2.timestamp
+    test "subscribes to new blocks":
+      let oldBlock = !await provider.getBlock(BlockTag.latest)
+      var newBlock: Block
+      let blockHandler = proc(blck: Block) {.async.} = newBlock = blck
+      let subscription = await provider.subscribe(blockHandler)
+      discard await provider.send("evm_mine")
+      check eventually newBlock.number.isSome
+      check !newBlock.number > !oldBlock.number
+      check newBlock.timestamp > oldBlock.timestamp
+      check newBlock.hash != oldBlock.hash
+      await subscription.unsubscribe()
 
-  test "subscribes to new blocks":
-    let oldBlock = !await provider.getBlock(BlockTag.latest)
-    var newBlock: Block
-    let blockHandler = proc(blck: Block) {.async.} = newBlock = blck
-    let subscription = await provider.subscribe(blockHandler)
-    discard await provider.send("evm_mine")
-    check !newBlock.number > !oldBlock.number
-    check newBlock.timestamp > oldBlock.timestamp
-    check newBlock.hash != oldBlock.hash
-    await subscription.unsubscribe()
+    test "can send a transaction":
+      let signer = provider.getSigner()
+      let transaction = Transaction.example
+      let populated = await signer.populateTransaction(transaction)
 
-  test "can send a transaction":
-    let signer = provider.getSigner()
-    let transaction = Transaction.example
-    let populated = await signer.populateTransaction(transaction)
+      let txResp = await signer.sendTransaction(populated)
+      check txResp.hash.len == 32
+      check UInt256.fromHex("0x" & txResp.hash.toHex) > 0
 
-    let txResp = await signer.sendTransaction(populated)
-    check txResp.hash.len == 32
-    check UInt256.fromHex("0x" & txResp.hash.toHex) > 0
+    test "can wait for a transaction to be confirmed":
+      let signer = provider.getSigner()
+      let transaction = Transaction.example
+      let populated = await signer.populateTransaction(transaction)
 
-  test "can wait for a transaction to be confirmed":
-    let signer = provider.getSigner()
-    let transaction = Transaction.example
-    let populated = await signer.populateTransaction(transaction)
+      # must not be awaited so we can get newHeads inside of .wait
+      let futMined = provider.mineBlocks(5)
 
-    # must not be awaited so we can get newHeads inside of .wait
-    let futMined = provider.mineBlocks(5)
-
-    let receipt = await signer.sendTransaction(populated).confirm(3)
-    let endBlock = await provider.getBlockNumber()
-
-    check receipt.blockNumber.isSome # was eventually mined
-
-    # >= 3 because more blocks may have been mined by the time the
-    # check in `.wait` was done.
-    # +1 for the block the tx was mined in
-    check (endBlock - !receipt.blockNumber) + 1 >= 3
-
-    await futMined
-
-  test "waiting for block to be mined times out":
-
-    # must not be awaited so we can get newHeads inside of .wait
-    let futMined = provider.mineBlocks(7)
-
-    let startBlock = await provider.getBlockNumber()
-    let response = TransactionResponse(hash: TransactionHash.example,
-                                      provider: provider)
-    try:
-      discard await response.confirm(wantedConfirms = 2,
-                                     timeoutInBlocks = 5)
-
-      await futMined
-    except EthersError as e:
-      check e.msg == "Transaction was not mined in 5 blocks"
-
+      let receipt = await signer.sendTransaction(populated).confirm(3)
       let endBlock = await provider.getBlockNumber()
 
-      # >= 5 because more blocks may have been mined by the time the
+      check receipt.blockNumber.isSome # was eventually mined
+
+      # >= 3 because more blocks may have been mined by the time the
       # check in `.wait` was done.
-      # +1 for including the start block
-      check (endBlock - startBlock) + 1 >= 5 # +1 including start block
-      if not futMined.completed and not futMined.finished: await futMined
+      # +1 for the block the tx was mined in
+      check (endBlock - !receipt.blockNumber) + 1 >= 3
 
-  test "Conversion: missing block number in Block isNone":
+      await futMined
 
-    var blkJson = %*{
-      "subscription": "0x20",
-      "result":{
-        "number": newJNull(),
-        "hash":"0x2d7d68c8f48b4213d232a1f12cab8c9fac6195166bb70a5fb21397984b9fe1c7",
-        "timestamp":"0x6285c293"
+    test "waiting for block to be mined times out":
+
+      # must not be awaited so we can get newHeads inside of .wait
+      let futMined = provider.mineBlocks(7)
+
+      let startBlock = await provider.getBlockNumber()
+      let response = TransactionResponse(hash: TransactionHash.example,
+                                        provider: provider)
+      try:
+        discard await response.confirm(wantedConfirms = 2,
+                                      timeoutInBlocks = 5)
+
+        await futMined
+      except EthersError as e:
+        check e.msg == "Transaction was not mined in 5 blocks"
+
+        let endBlock = await provider.getBlockNumber()
+
+        # >= 5 because more blocks may have been mined by the time the
+        # check in `.wait` was done.
+        # +1 for including the start block
+        check (endBlock - startBlock) + 1 >= 5 # +1 including start block
+        if not futMined.completed and not futMined.finished: await futMined
+
+    test "Conversion: missing block number in Block isNone":
+
+      var blkJson = %*{
+        "subscription": "0x20",
+        "result":{
+          "number": newJNull(),
+          "hash":"0x2d7d68c8f48b4213d232a1f12cab8c9fac6195166bb70a5fb21397984b9fe1c7",
+          "timestamp":"0x6285c293"
+        }
       }
-    }
 
-    var blk = Block.fromJson(blkJson["result"])
-    check blk.number.isNone
+      var blk = Block.fromJson(blkJson["result"])
+      check blk.number.isNone
 
-    blkJson["result"]["number"] = newJString("")
+      blkJson["result"]["number"] = newJString("")
 
-    blk = Block.fromJson(blkJson["result"])
-    check blk.number.isSome
-    check blk.number.get.isZero
+      blk = Block.fromJson(blkJson["result"])
+      check blk.number.isSome
+      check blk.number.get.isZero
 
   test "Conversion: missing block hash in Block isNone":
 
@@ -142,132 +139,132 @@ suite "JsonRpcProvider":
     var blk = Block.fromJson(blkJson["result"])
     check blk.hash.isNone
 
-  test "Conversion: missing block number in TransactionReceipt isNone":
+    test "Conversion: missing block number in TransactionReceipt isNone":
 
-    var txReceiptJson = %*{
-      "sender": newJNull(),
-      "to": "0x5fbdb2315678afecb367f032d93f642f64180aa3",
-      "contractAddress": newJNull(),
-      "transactionIndex": "0x0",
-      "gasUsed": "0x10db1",
-      "logsBloom": "0x00000000000000000002000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000840020000000000000000000800000000000000000000000010000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000000000000000042000000000000000000000000000000000000000000000000000020000000000000000000000000000000000001000000000000000000000000000000",
-      "blockHash": "0x7b00154e06fe4f27a87208eba220efb4dbc52f7429549a39a17bba2e0d98b960",
-      "transactionHash": "0xa64f07b370cbdcce381ec9bfb6c8004684341edfb6848fd418189969d4b9139c",
-      "logs": [
-        {
-          "data": "0x0000000000000000000000000000000000000000000000000000000000000064",
-          "topics": [
-            "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-            "0x0000000000000000000000000000000000000000000000000000000000000000",
-            "0x00000000000000000000000070997970c51812dc3a010c7d01b50e0d17dc79c8"
-          ]
-        }
-      ],
-      "blockNumber": newJNull(),
-      "cumulativeGasUsed": "0x10db1",
-      "status": "0000000000000001"
-    }
+      var txReceiptJson = %*{
+        "sender": newJNull(),
+        "to": "0x5fbdb2315678afecb367f032d93f642f64180aa3",
+        "contractAddress": newJNull(),
+        "transactionIndex": "0x0",
+        "gasUsed": "0x10db1",
+        "logsBloom": "0x00000000000000000002000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000840020000000000000000000800000000000000000000000010000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000000000000000042000000000000000000000000000000000000000000000000000020000000000000000000000000000000000001000000000000000000000000000000",
+        "blockHash": "0x7b00154e06fe4f27a87208eba220efb4dbc52f7429549a39a17bba2e0d98b960",
+        "transactionHash": "0xa64f07b370cbdcce381ec9bfb6c8004684341edfb6848fd418189969d4b9139c",
+        "logs": [
+          {
+            "data": "0x0000000000000000000000000000000000000000000000000000000000000064",
+            "topics": [
+              "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+              "0x0000000000000000000000000000000000000000000000000000000000000000",
+              "0x00000000000000000000000070997970c51812dc3a010c7d01b50e0d17dc79c8"
+            ]
+          }
+        ],
+        "blockNumber": newJNull(),
+        "cumulativeGasUsed": "0x10db1",
+        "status": "0000000000000001"
+      }
 
-    var txReceipt = TransactionReceipt.fromJson(txReceiptJson)
-    check txReceipt.blockNumber.isNone
+      var txReceipt = TransactionReceipt.fromJson(txReceiptJson)
+      check txReceipt.blockNumber.isNone
 
-    txReceiptJson["blockNumber"] = newJString("")
-    txReceipt = TransactionReceipt.fromJson(txReceiptJson)
-    check txReceipt.blockNumber.isSome
-    check txReceipt.blockNumber.get.isZero
+      txReceiptJson["blockNumber"] = newJString("")
+      txReceipt = TransactionReceipt.fromJson(txReceiptJson)
+      check txReceipt.blockNumber.isSome
+      check txReceipt.blockNumber.get.isZero
 
-  test "Conversion: missing block hash in TransactionReceipt isNone":
+    test "Conversion: missing block hash in TransactionReceipt isNone":
 
-    var txReceiptJson = %*{
-      "sender": newJNull(),
-      "to": "0x5fbdb2315678afecb367f032d93f642f64180aa3",
-      "contractAddress": newJNull(),
-      "transactionIndex": "0x0",
-      "gasUsed": "0x10db1",
-      "logsBloom": "0x00000000000000000002000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000840020000000000000000000800000000000000000000000010000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000000000000000042000000000000000000000000000000000000000000000000000020000000000000000000000000000000000001000000000000000000000000000000",
-      "blockHash":  newJNull(),
-      "transactionHash": "0xa64f07b370cbdcce381ec9bfb6c8004684341edfb6848fd418189969d4b9139c",
-      "logs": [
-        {
-          "data": "0x0000000000000000000000000000000000000000000000000000000000000064",
-          "topics": [
-            "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-            "0x0000000000000000000000000000000000000000000000000000000000000000",
-            "0x00000000000000000000000070997970c51812dc3a010c7d01b50e0d17dc79c8"
-          ]
-        }
-      ],
-      "blockNumber": newJNull(),
-      "cumulativeGasUsed": "0x10db1",
-      "status": "0000000000000001"
-    }
+      var txReceiptJson = %*{
+        "sender": newJNull(),
+        "to": "0x5fbdb2315678afecb367f032d93f642f64180aa3",
+        "contractAddress": newJNull(),
+        "transactionIndex": "0x0",
+        "gasUsed": "0x10db1",
+        "logsBloom": "0x00000000000000000002000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000840020000000000000000000800000000000000000000000010000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000000000000000042000000000000000000000000000000000000000000000000000020000000000000000000000000000000000001000000000000000000000000000000",
+        "blockHash":  newJNull(),
+        "transactionHash": "0xa64f07b370cbdcce381ec9bfb6c8004684341edfb6848fd418189969d4b9139c",
+        "logs": [
+          {
+            "data": "0x0000000000000000000000000000000000000000000000000000000000000064",
+            "topics": [
+              "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
+              "0x0000000000000000000000000000000000000000000000000000000000000000",
+              "0x00000000000000000000000070997970c51812dc3a010c7d01b50e0d17dc79c8"
+            ]
+          }
+        ],
+        "blockNumber": newJNull(),
+        "cumulativeGasUsed": "0x10db1",
+        "status": "0000000000000001"
+      }
 
-    var txReceipt = TransactionReceipt.fromJson(txReceiptJson)
-    check txReceipt.blockHash.isNone
+      var txReceipt = TransactionReceipt.fromJson(txReceiptJson)
+      check txReceipt.blockHash.isNone
 
-  test "confirmations calculated correctly":
-    # when receipt block number is higher than current block number,
-    # should return 0
-    check confirmations(2.u256, 1.u256) == 0.u256
+    test "confirmations calculated correctly":
+      # when receipt block number is higher than current block number,
+      # should return 0
+      check confirmations(2.u256, 1.u256) == 0.u256
 
-    # Same receipt and current block counts as one confirmation
-    check confirmations(1.u256, 1.u256) == 1.u256
+      # Same receipt and current block counts as one confirmation
+      check confirmations(1.u256, 1.u256) == 1.u256
 
-    check confirmations(1.u256, 2.u256) == 2.u256
+      check confirmations(1.u256, 2.u256) == 2.u256
 
-  test "checks if transation has been mined correctly":
+    test "checks if transation has been mined correctly":
 
-    var receipt: TransactionReceipt
-    var currentBlock = 1.u256
-    var wantedConfirms = 1
-    let blockHash = hexToByteArray[32](
-      "0x7b00154e06fe4f27a87208eba220efb4dbc52f7429549a39a17bba2e0d98b960"
-    ).some
+      var receipt: TransactionReceipt
+      var currentBlock = 1.u256
+      var wantedConfirms = 1
+      let blockHash = hexToByteArray[32](
+        "0x7b00154e06fe4f27a87208eba220efb4dbc52f7429549a39a17bba2e0d98b960"
+      ).some
 
-    # missing blockHash
-    receipt = TransactionReceipt(
-      blockNumber: 1.u256.some
-    )
-    check not receipt.hasBeenMined(currentBlock, wantedConfirms)
+      # missing blockHash
+      receipt = TransactionReceipt(
+        blockNumber: 1.u256.some
+      )
+      check not receipt.hasBeenMined(currentBlock, wantedConfirms)
 
-    # missing block number
-    receipt = TransactionReceipt(
-      blockHash: blockHash
-    )
-    check not receipt.hasBeenMined(currentBlock, wantedConfirms)
+      # missing block number
+      receipt = TransactionReceipt(
+        blockHash: blockHash
+      )
+      check not receipt.hasBeenMined(currentBlock, wantedConfirms)
 
-    # block number is 0
-    receipt = TransactionReceipt(
-      blockNumber: 0.u256.some
-    )
-    check not receipt.hasBeenMined(currentBlock, wantedConfirms)
+      # block number is 0
+      receipt = TransactionReceipt(
+        blockNumber: 0.u256.some
+      )
+      check not receipt.hasBeenMined(currentBlock, wantedConfirms)
 
-    # not enough confirms
-    receipt = TransactionReceipt(
-      blockNumber: 1.u256.some
-    )
-    check not receipt.hasBeenMined(currentBlock, wantedConfirms)
+      # not enough confirms
+      receipt = TransactionReceipt(
+        blockNumber: 1.u256.some
+      )
+      check not receipt.hasBeenMined(currentBlock, wantedConfirms)
 
-    # success
-    receipt = TransactionReceipt(
-      blockNumber: 1.u256.some,
-      blockHash: blockHash
-    )
-    currentBlock = int.high.u256
-    wantedConfirms = int.high
-    check receipt.hasBeenMined(currentBlock, wantedConfirms)
+      # success
+      receipt = TransactionReceipt(
+        blockNumber: 1.u256.some,
+        blockHash: blockHash
+      )
+      currentBlock = int.high.u256
+      wantedConfirms = int.high
+      check receipt.hasBeenMined(currentBlock, wantedConfirms)
 
-  test "raises JsonRpcProviderError when something goes wrong":
-    let provider = JsonRpcProvider.new("http://invalid.")
-    expect JsonRpcProviderError:
-      discard await provider.listAccounts()
-    expect JsonRpcProviderError:
-      discard await provider.send("evm_mine")
-    expect JsonRpcProviderError:
-      discard await provider.getBlockNumber()
-    expect JsonRpcProviderError:
-      discard await provider.getBlock(BlockTag.latest)
-    expect JsonRpcProviderError:
-      discard await provider.subscribe(proc(_: Block) {.async.} = discard)
-    expect JsonRpcProviderError:
-      discard await provider.getSigner().sendTransaction(Transaction.example)
+    test "raises JsonRpcProviderError when something goes wrong":
+      let provider = JsonRpcProvider.new("http://invalid.")
+      expect JsonRpcProviderError:
+        discard await provider.listAccounts()
+      expect JsonRpcProviderError:
+        discard await provider.send("evm_mine")
+      expect JsonRpcProviderError:
+        discard await provider.getBlockNumber()
+      expect JsonRpcProviderError:
+        discard await provider.getBlock(BlockTag.latest)
+      expect JsonRpcProviderError:
+        discard await provider.subscribe(proc(_: Block) {.async.} = discard)
+      expect JsonRpcProviderError:
+        discard await provider.getSigner().sendTransaction(Transaction.example)

--- a/testmodule/providers/jsonrpc/testJsonRpcProvider.nim
+++ b/testmodule/providers/jsonrpc/testJsonRpcProvider.nim
@@ -4,8 +4,8 @@ import pkg/chronos
 import pkg/ethers
 import pkg/ethers/providers/jsonrpc/conversions
 import pkg/stew/byteutils
-import ./examples
-import ./miner
+import ../../examples
+import ../../miner
 
 suite "JsonRpcProvider":
 

--- a/testmodule/providers/jsonrpc/testJsonRpcProvider.nim
+++ b/testmodule/providers/jsonrpc/testJsonRpcProvider.nim
@@ -16,6 +16,10 @@ for url in ["ws://localhost:8545", "http://localhost:8545"]:
     setup:
       provider = JsonRpcProvider.new(url, pollingInterval = 100.millis)
 
+
+    teardown:
+      await provider.close()
+
     test "can be instantiated with a default URL":
       discard JsonRpcProvider.new()
 

--- a/testmodule/providers/jsonrpc/testJsonRpcProvider.nim
+++ b/testmodule/providers/jsonrpc/testJsonRpcProvider.nim
@@ -14,7 +14,7 @@ for url in ["ws://localhost:8545", "http://localhost:8545"]:
     var provider: JsonRpcProvider
 
     setup:
-      provider = JsonRpcProvider.new(url)
+      provider = JsonRpcProvider.new(url, pollingInterval = 100.millis)
 
     test "can be instantiated with a default URL":
       discard JsonRpcProvider.new()

--- a/testmodule/providers/jsonrpc/testJsonRpcSigner.nim
+++ b/testmodule/providers/jsonrpc/testJsonRpcSigner.nim
@@ -1,7 +1,7 @@
 import pkg/asynctest
 import pkg/ethers
 import pkg/stew/byteutils
-import ./examples
+import ../../examples
 
 suite "JsonRpcSigner":
 

--- a/testmodule/providers/jsonrpc/testJsonRpcSigner.nim
+++ b/testmodule/providers/jsonrpc/testJsonRpcSigner.nim
@@ -12,6 +12,9 @@ suite "JsonRpcSigner":
     provider = JsonRpcProvider.new()
     accounts = await provider.listAccounts()
 
+  teardown:
+    await provider.close()
+
   test "is connected to the first account of the provider by default":
     let signer = provider.getSigner()
     check (await signer.getAddress()) == accounts[0]

--- a/testmodule/providers/jsonrpc/testJsonRpcSubscriptions.nim
+++ b/testmodule/providers/jsonrpc/testJsonRpcSubscriptions.nim
@@ -27,7 +27,7 @@ template subscriptionTests(subscriptions, client) =
     check eventually latestBlock.number.isSome
     check latestBlock.hash.isSome
     check latestBlock.timestamp > 0.u256
-    await subscription.unsubscribe()
+    await subscriptions.unsubscribe(subscription)
 
   test "stops listening to new blocks when unsubscribed":
     var count = 0
@@ -36,7 +36,7 @@ template subscriptionTests(subscriptions, client) =
     let subscription = await subscriptions.subscribeBlocks(callback)
     discard await client.call("evm_mine", newJArray())
     check eventually count > 0
-    await subscription.unsubscribe()
+    await subscriptions.unsubscribe(subscription)
     count = 0
     discard await client.call("evm_mine", newJArray())
     await sleepAsync(100.millis)

--- a/testmodule/providers/jsonrpc/testJsonRpcSubscriptions.nim
+++ b/testmodule/providers/jsonrpc/testJsonRpcSubscriptions.nim
@@ -49,6 +49,7 @@ suite "HTTP polling subscriptions":
   setup:
     client = newRpcHttpClient()
     await client.connect("http://localhost:8545")
-    subscriptions = JsonRpcSubscriptions.new(client)
+    subscriptions = JsonRpcSubscriptions.new(client,
+                                             pollingInterval = 100.millis)
 
   subscriptionTests(subscriptions, client)

--- a/testmodule/providers/jsonrpc/testJsonRpcSubscriptions.nim
+++ b/testmodule/providers/jsonrpc/testJsonRpcSubscriptions.nim
@@ -1,0 +1,38 @@
+import std/json
+import pkg/asynctest
+import pkg/json_rpc/rpcclient
+import ethers/provider
+import ethers/providers/jsonrpc/subscriptions
+
+suite "JsonRpcSubscriptions":
+
+  test "can be instantiated with an http client":
+    let client = newRpcHttpClient()
+    let subscriptions = JsonRpcSubscriptions.new(client)
+    check not isNil subscriptions
+
+  test "can be instantiated with a websocket client":
+    let client = newRpcWebSocketClient()
+    let subscriptions = JsonRpcSubscriptions.new(client)
+    check not isNil subscriptions
+
+suite "Web socket subscriptions":
+
+  var subscriptions: JsonRpcSubscriptions
+  var client: RpcWebSocketClient
+
+  setup:
+    client = newRpcWebSocketClient()
+    await client.connect("ws://localhost:8545")
+    subscriptions = JsonRpcSubscriptions.new(client)
+
+  test "subscribes to new blocks":
+    var latestBlock: Block
+    proc callback(blck: Block) {.async.} =
+      latestBlock = blck
+    let subscription = await subscriptions.subscribeBlocks(callback)
+    discard await client.call("evm_mine", newJArray())
+    check eventually(latestBlock.number.isSome)
+    check latestBlock.hash.isSome
+    check latestBlock.timestamp > 0.u256
+    await subscription.unsubscribe()

--- a/testmodule/providers/testJsonRpc.nim
+++ b/testmodule/providers/testJsonRpc.nim
@@ -1,4 +1,5 @@
 import ./jsonrpc/testJsonRpcProvider
 import ./jsonrpc/testJsonRpcSigner
+import ./jsonrpc/testJsonRpcSubscriptions
 
 {.warning[UnusedImport]:off.}

--- a/testmodule/providers/testJsonRpc.nim
+++ b/testmodule/providers/testJsonRpc.nim
@@ -1,0 +1,4 @@
+import ./jsonrpc/testJsonRpcProvider
+import ./jsonrpc/testJsonRpcSigner
+
+{.warning[UnusedImport]:off.}

--- a/testmodule/test.nim
+++ b/testmodule/test.nim
@@ -1,5 +1,4 @@
-import ./testJsonRpcProvider
-import ./testJsonRpcSigner
+import ./testProviders
 import ./testContracts
 import ./testReturns
 import ./testEnums

--- a/testmodule/test.nimble
+++ b/testmodule/test.nimble
@@ -3,7 +3,7 @@ author = "Nim Ethers Authors"
 description = "Tests for Nim Ethers library"
 license = "MIT"
 
-requires "asynctest >= 0.3.2 & < 0.4.0"
+requires "asynctest >= 0.4.0 & < 0.5.0"
 requires "questionable >= 0.10.3 & < 0.11.0"
 
 task test, "Run the test suite":

--- a/testmodule/testContracts.nim
+++ b/testmodule/testContracts.nim
@@ -15,179 +15,185 @@ type
 method mint(token: TestToken, holder: Address, amount: UInt256): ?TransactionResponse {.base, contract.}
 method myBalance(token: TestToken): UInt256 {.contract, view.}
 
-suite "Contracts":
+for url in ["ws://localhost:8545", "http://localhost:8545"]:
 
-  var token: TestToken
-  var provider: JsonRpcProvider
-  var snapshot: JsonNode
-  var accounts: seq[Address]
+  suite "Contracts (" & url & ")":
 
-  setup:
-    provider = JsonRpcProvider.new("ws://localhost:8545")
-    snapshot = await provider.send("evm_snapshot")
-    accounts = await provider.listAccounts()
-    let deployment = readDeployment()
-    token = TestToken.new(!deployment.address(TestToken), provider)
+    var token: TestToken
+    var provider: JsonRpcProvider
+    var snapshot: JsonNode
+    var accounts: seq[Address]
 
-  teardown:
-    discard await provider.send("evm_revert", @[snapshot])
+    setup:
+      provider = JsonRpcProvider.new(url, pollingInterval = 100.millis)
+      snapshot = await provider.send("evm_snapshot")
+      accounts = await provider.listAccounts()
+      let deployment = readDeployment()
+      token = TestToken.new(!deployment.address(TestToken), provider)
 
-  test "can call constant functions":
-    check (await token.name()) == "TestToken"
-    check (await token.totalSupply()) == 0.u256
-    check (await token.balanceOf(accounts[0])) == 0.u256
-    check (await token.allowance(accounts[0], accounts[1])) == 0.u256
+    teardown:
+      discard await provider.send("evm_revert", @[snapshot])
 
-  test "can call non-constant functions":
-    token = TestToken.new(token.address, provider.getSigner())
-    discard await token.mint(accounts[1], 100.u256)
-    check (await token.totalSupply()) == 100.u256
-    check (await token.balanceOf(accounts[1])) == 100.u256
+    test "can call constant functions":
+      check (await token.name()) == "TestToken"
+      check (await token.totalSupply()) == 0.u256
+      check (await token.balanceOf(accounts[0])) == 0.u256
+      check (await token.allowance(accounts[0], accounts[1])) == 0.u256
 
-  test "can call constant functions with a signer and the account is used for the call":
-    let signer0 = provider.getSigner(accounts[0])
-    let signer1 = provider.getSigner(accounts[1])
-    discard await token.connect(signer0).mint(accounts[1], 100.u256)
-    check (await token.connect(signer0).myBalance()) == 0.u256
-    check (await token.connect(signer1).myBalance()) == 100.u256
+    test "can call non-constant functions":
+      token = TestToken.new(token.address, provider.getSigner())
+      discard await token.mint(accounts[1], 100.u256)
+      check (await token.totalSupply()) == 100.u256
+      check (await token.balanceOf(accounts[1])) == 100.u256
 
-  test "can call non-constant functions without a signer":
-    discard await token.mint(accounts[1], 100.u256)
-    check (await token.balanceOf(accounts[1])) == 0.u256
+    test "can call constant functions with a signer and the account is used for the call":
+      let signer0 = provider.getSigner(accounts[0])
+      let signer1 = provider.getSigner(accounts[1])
+      discard await token.connect(signer0).mint(accounts[1], 100.u256)
+      check (await token.connect(signer0).myBalance()) == 0.u256
+      check (await token.connect(signer1).myBalance()) == 100.u256
 
-  test "can call constant functions without a return type":
-    token = TestToken.new(token.address, provider.getSigner())
-    proc mint(token: TestToken, holder: Address, amount: UInt256) {.contract, view.}
-    await mint(token, accounts[1], 100.u256)
-    check (await balanceOf(token, accounts[1])) == 0.u256
+    test "can call non-constant functions without a signer":
+      discard await token.mint(accounts[1], 100.u256)
+      check (await token.balanceOf(accounts[1])) == 0.u256
 
-  test "can call non-constant functions without a return type":
-    token = TestToken.new(token.address, provider.getSigner())
-    proc mint(token: TestToken, holder: Address, amount: UInt256) {.contract.}
-    await token.mint(accounts[1], 100.u256)
-    check (await balanceOf(token, accounts[1])) == 100.u256
+    test "can call constant functions without a return type":
+      token = TestToken.new(token.address, provider.getSigner())
+      proc mint(token: TestToken, holder: Address, amount: UInt256) {.contract, view.}
+      await mint(token, accounts[1], 100.u256)
+      check (await balanceOf(token, accounts[1])) == 0.u256
 
-  test "can call non-constant functions with a ?TransactionResponse return type":
-    token = TestToken.new(token.address, provider.getSigner())
-    proc mint(token: TestToken,
-              holder: Address,
-              amount: UInt256): ?TransactionResponse {.contract.}
-    let txResp = await token.mint(accounts[1], 100.u256)
-    check txResp is (?TransactionResponse)
-    check txResp.isSome
+    test "can call non-constant functions without a return type":
+      token = TestToken.new(token.address, provider.getSigner())
+      proc mint(token: TestToken, holder: Address, amount: UInt256) {.contract.}
+      await token.mint(accounts[1], 100.u256)
+      check (await balanceOf(token, accounts[1])) == 100.u256
 
-  test "can call non-constant functions with a Confirmable return type":
+    test "can call non-constant functions with a ?TransactionResponse return type":
+      token = TestToken.new(token.address, provider.getSigner())
+      proc mint(token: TestToken,
+                holder: Address,
+                amount: UInt256): ?TransactionResponse {.contract.}
+      let txResp = await token.mint(accounts[1], 100.u256)
+      check txResp is (?TransactionResponse)
+      check txResp.isSome
 
-    token = TestToken.new(token.address, provider.getSigner())
-    proc mint(token: TestToken,
-              holder: Address,
-              amount: UInt256): Confirmable {.contract.}
-    let txResp = await token.mint(accounts[1], 100.u256)
-    check txResp is Confirmable
-    check txResp.isSome
+    test "can call non-constant functions with a Confirmable return type":
 
-  test "fails to compile when function has an implementation":
-    let works = compiles:
-      proc foo(token: TestToken, bar: Address) {.contract.} = discard
-    check not works
+      token = TestToken.new(token.address, provider.getSigner())
+      proc mint(token: TestToken,
+                holder: Address,
+                amount: UInt256): Confirmable {.contract.}
+      let txResp = await token.mint(accounts[1], 100.u256)
+      check txResp is Confirmable
+      check txResp.isSome
 
-  test "fails to compile when function has no parameters":
-    let works = compiles:
-      proc foo() {.contract.}
-    check not works
+    test "fails to compile when function has an implementation":
+      let works = compiles:
+        proc foo(token: TestToken, bar: Address) {.contract.} = discard
+      check not works
 
-  test "fails to compile when non-constant function has a return type":
-    let works = compiles:
-      proc foo(token: TestToken, bar: Address): UInt256 {.contract.}
-    check not works
+    test "fails to compile when function has no parameters":
+      let works = compiles:
+        proc foo() {.contract.}
+      check not works
 
-  test "can connect to different providers and signers":
-    let signer0 = provider.getSigner(accounts[0])
-    let signer1 = provider.getSigner(accounts[1])
-    discard await token.connect(signer0).mint(accounts[0], 100.u256)
-    await token.connect(signer0).transfer(accounts[1], 50.u256)
-    await token.connect(signer1).transfer(accounts[2], 25.u256)
-    check (await token.connect(provider).balanceOf(accounts[0])) == 50.u256
-    check (await token.connect(provider).balanceOf(accounts[1])) == 25.u256
-    check (await token.connect(provider).balanceOf(accounts[2])) == 25.u256
+    test "fails to compile when non-constant function has a return type":
+      let works = compiles:
+        proc foo(token: TestToken, bar: Address): UInt256 {.contract.}
+      check not works
 
-  test "takes custom values for nonce, gasprice and gaslimit":
-    let overrides = TransactionOverrides(
-      nonce: some 100.u256,
-      gasPrice: some 200.u256,
-      gasLimit: some 300.u256
-    )
-    let signer = MockSigner.new(provider)
-    discard await token.connect(signer).mint(accounts[0], 42.u256, overrides)
-    check signer.transactions.len == 1
-    check signer.transactions[0].nonce == overrides.nonce
-    check signer.transactions[0].gasPrice == overrides.gasPrice
-    check signer.transactions[0].gasLimit == overrides.gasLimit
+    test "can connect to different providers and signers":
+      let signer0 = provider.getSigner(accounts[0])
+      let signer1 = provider.getSigner(accounts[1])
+      discard await token.connect(signer0).mint(accounts[0], 100.u256)
+      await token.connect(signer0).transfer(accounts[1], 50.u256)
+      await token.connect(signer1).transfer(accounts[2], 25.u256)
+      check (await token.connect(provider).balanceOf(accounts[0])) == 50.u256
+      check (await token.connect(provider).balanceOf(accounts[1])) == 25.u256
+      check (await token.connect(provider).balanceOf(accounts[2])) == 25.u256
 
-  test "can call functions for different block heights":
-    let block1 = await provider.getBlockNumber()
-    let signer = provider.getSigner(accounts[0])
-    discard await token.connect(signer).mint(accounts[0], 100.u256)
-    let block2 = await provider.getBlockNumber()
+    test "takes custom values for nonce, gasprice and gaslimit":
+      let overrides = TransactionOverrides(
+        nonce: some 100.u256,
+        gasPrice: some 200.u256,
+        gasLimit: some 300.u256
+      )
+      let signer = MockSigner.new(provider)
+      discard await token.connect(signer).mint(accounts[0], 42.u256, overrides)
+      check signer.transactions.len == 1
+      check signer.transactions[0].nonce == overrides.nonce
+      check signer.transactions[0].gasPrice == overrides.gasPrice
+      check signer.transactions[0].gasLimit == overrides.gasLimit
 
-    let beforeMint = CallOverrides(blockTag: some BlockTag.init(block1))
-    let afterMint = CallOverrides(blockTag: some BlockTag.init(block2))
+    test "can call functions for different block heights":
+      let block1 = await provider.getBlockNumber()
+      let signer = provider.getSigner(accounts[0])
+      discard await token.connect(signer).mint(accounts[0], 100.u256)
+      let block2 = await provider.getBlockNumber()
 
-    check (await token.balanceOf(accounts[0], beforeMint)) == 0
-    check (await token.balanceOf(accounts[0], afterMint)) == 100
+      let beforeMint = CallOverrides(blockTag: some BlockTag.init(block1))
+      let afterMint = CallOverrides(blockTag: some BlockTag.init(block2))
 
-  test "receives events when subscribed":
-    var transfers: seq[Transfer]
+      check (await token.balanceOf(accounts[0], beforeMint)) == 0
+      check (await token.balanceOf(accounts[0], afterMint)) == 100
 
-    proc handleTransfer(transfer: Transfer) =
-      transfers.add(transfer)
+    test "receives events when subscribed":
+      var transfers: seq[Transfer]
 
-    let signer0 = provider.getSigner(accounts[0])
-    let signer1 = provider.getSigner(accounts[1])
+      proc handleTransfer(transfer: Transfer) =
+        transfers.add(transfer)
 
-    let subscription = await token.subscribe(Transfer, handleTransfer)
-    discard await token.connect(signer0).mint(accounts[0], 100.u256)
-    await token.connect(signer0).transfer(accounts[1], 50.u256)
-    await token.connect(signer1).transfer(accounts[2], 25.u256)
-    await subscription.unsubscribe()
+      let signer0 = provider.getSigner(accounts[0])
+      let signer1 = provider.getSigner(accounts[1])
 
-    check transfers == @[
-      Transfer(receiver: accounts[0], value: 100.u256),
-      Transfer(sender: accounts[0], receiver: accounts[1], value: 50.u256),
-      Transfer(sender: accounts[1], receiver: accounts[2], value: 25.u256)
-    ]
+      let subscription = await token.subscribe(Transfer, handleTransfer)
+      discard await token.connect(signer0).mint(accounts[0], 100.u256)
+      await token.connect(signer0).transfer(accounts[1], 50.u256)
+      await token.connect(signer1).transfer(accounts[2], 25.u256)
 
-  test "stops receiving events when unsubscribed":
-    var transfers: seq[Transfer]
+      check eventually transfers == @[
+        Transfer(receiver: accounts[0], value: 100.u256),
+        Transfer(sender: accounts[0], receiver: accounts[1], value: 50.u256),
+        Transfer(sender: accounts[1], receiver: accounts[2], value: 25.u256)
+      ]
 
-    proc handleTransfer(transfer: Transfer) =
-      transfers.add(transfer)
+      await subscription.unsubscribe()
 
-    let signer0 = provider.getSigner(accounts[0])
+    test "stops receiving events when unsubscribed":
+      var transfers: seq[Transfer]
 
-    let subscription = await token.subscribe(Transfer, handleTransfer)
-    discard await token.connect(signer0).mint(accounts[0], 100.u256)
-    await subscription.unsubscribe()
+      proc handleTransfer(transfer: Transfer) =
+        transfers.add(transfer)
 
-    await token.connect(signer0).transfer(accounts[1], 50.u256)
+      let signer0 = provider.getSigner(accounts[0])
 
-    check transfers == @[Transfer(receiver: accounts[0], value: 100.u256)]
+      let subscription = await token.subscribe(Transfer, handleTransfer)
+      discard await token.connect(signer0).mint(accounts[0], 100.u256)
 
-  test "can wait for contract interaction tx to be mined":
-    # must not be awaited so we can get newHeads inside of .wait
-    let futMined = provider.mineBlocks(10)
+      check eventually transfers.len == 1
+      await subscription.unsubscribe()
 
-    let signer0 = provider.getSigner(accounts[0])
-    let receipt = await token.connect(signer0)
-                    .mint(accounts[1], 100.u256)
-                    .confirm(3) # wait for 3 confirmations
-    let endBlock = await provider.getBlockNumber()
+      await token.connect(signer0).transfer(accounts[1], 50.u256)
+      await sleepAsync(100.millis)
 
-    check receipt.blockNumber.isSome # was eventually mined
+      check transfers.len == 1
 
-    # >= 3 because more blocks may have been mined by the time the
-    # check in `.wait` was done.
-    # +1 for the block the tx was mined in
-    check (endBlock - !receipt.blockNumber) + 1 >= 3
+    test "can wait for contract interaction tx to be mined":
+      # must not be awaited so we can get newHeads inside of .wait
+      let futMined = provider.mineBlocks(10)
 
-    await futMined
+      let signer0 = provider.getSigner(accounts[0])
+      let receipt = await token.connect(signer0)
+                      .mint(accounts[1], 100.u256)
+                      .confirm(3) # wait for 3 confirmations
+      let endBlock = await provider.getBlockNumber()
+
+      check receipt.blockNumber.isSome # was eventually mined
+
+      # >= 3 because more blocks may have been mined by the time the
+      # check in `.wait` was done.
+      # +1 for the block the tx was mined in
+      check (endBlock - !receipt.blockNumber) + 1 >= 3
+
+      await futMined

--- a/testmodule/testContracts.nim
+++ b/testmodule/testContracts.nim
@@ -33,6 +33,7 @@ for url in ["ws://localhost:8545", "http://localhost:8545"]:
 
     teardown:
       discard await provider.send("evm_revert", @[snapshot])
+      await provider.close()
 
     test "can call constant functions":
       check (await token.name()) == "TestToken"

--- a/testmodule/testEnums.nim
+++ b/testmodule/testEnums.nim
@@ -22,6 +22,7 @@ suite "Contract enum parameters and return values":
 
   teardown:
     discard await provider.send("evm_revert", @[snapshot])
+    await provider.close()
 
   test "handles enum parameter and return value":
     proc returnValue(contract: TestEnums,

--- a/testmodule/testEnums.nim
+++ b/testmodule/testEnums.nim
@@ -15,7 +15,7 @@ suite "Contract enum parameters and return values":
   var snapshot: JsonNode
 
   setup:
-    provider = JsonRpcProvider.new("ws://localhost:8545")
+    provider = JsonRpcProvider.new()
     snapshot = await provider.send("evm_snapshot")
     let deployment = readDeployment()
     contract = TestEnums.new(!deployment.address(TestEnums), provider)

--- a/testmodule/testErc20.nim
+++ b/testmodule/testErc20.nim
@@ -13,84 +13,86 @@ type
 
 method mint(token: TestToken, holder: Address, amount: UInt256): ?TransactionResponse {.base, contract.}
 
-suite "ERC20":
+for url in ["ws://localhost:8545", "http://localhost:8545"]:
 
-  var token, token1: Erc20Token
-  var testToken: TestToken
-  var provider: JsonRpcProvider
-  var snapshot: JsonNode
-  var accounts: seq[Address]
+  suite "ERC20 (" & url & ")":
 
-  setup:
-    provider = JsonRpcProvider.new("ws://localhost:8545")
-    snapshot = await provider.send("evm_snapshot")
-    accounts = await provider.listAccounts()
-    let deployment = readDeployment()
-    testToken = TestToken.new(!deployment.address(TestToken), provider.getSigner())
-    token = Erc20Token.new(!deployment.address(TestToken), provider.getSigner())
+    var token, token1: Erc20Token
+    var testToken: TestToken
+    var provider: JsonRpcProvider
+    var snapshot: JsonNode
+    var accounts: seq[Address]
 
-  teardown:
-    discard await provider.send("evm_revert", @[snapshot])
+    setup:
+      provider = JsonRpcProvider.new(url, pollingInterval = 100.millis)
+      snapshot = await provider.send("evm_snapshot")
+      accounts = await provider.listAccounts()
+      let deployment = readDeployment()
+      testToken = TestToken.new(!deployment.address(TestToken), provider.getSigner())
+      token = Erc20Token.new(!deployment.address(TestToken), provider.getSigner())
 
-  test "retrieves basic information":
-    check (await token.name()) == "TestToken"
-    check (await token.symbol()) == "TST"
-    check (await token.decimals()) == 12
-    check (await token.totalSupply()) == 0.u256
-    check (await token.balanceOf(accounts[0])) == 0.u256
-    check (await token.allowance(accounts[0], accounts[1])) == 0.u256
+    teardown:
+      discard await provider.send("evm_revert", @[snapshot])
 
-  test "transfer tokens":
-    check (await token.balanceOf(accounts[0])) == 0.u256
-    check (await token.allowance(accounts[0], accounts[1])) == 0.u256
+    test "retrieves basic information":
+      check (await token.name()) == "TestToken"
+      check (await token.symbol()) == "TST"
+      check (await token.decimals()) == 12
+      check (await token.totalSupply()) == 0.u256
+      check (await token.balanceOf(accounts[0])) == 0.u256
+      check (await token.allowance(accounts[0], accounts[1])) == 0.u256
 
-    discard await testToken.mint(accounts[0], 100.u256)
+    test "transfer tokens":
+      check (await token.balanceOf(accounts[0])) == 0.u256
+      check (await token.allowance(accounts[0], accounts[1])) == 0.u256
 
-    check (await token.totalSupply()) == 100.u256
-    check (await token.balanceOf(accounts[0])) == 100.u256
-    check (await token.balanceOf(accounts[1])) == 0.u256
+      discard await testToken.mint(accounts[0], 100.u256)
 
-    await token.transfer(accounts[1], 50.u256)
+      check (await token.totalSupply()) == 100.u256
+      check (await token.balanceOf(accounts[0])) == 100.u256
+      check (await token.balanceOf(accounts[1])) == 0.u256
 
-    check (await token.balanceOf(accounts[0])) == 50.u256
-    check (await token.balanceOf(accounts[1])) == 50.u256
+      await token.transfer(accounts[1], 50.u256)
 
-  test "approve tokens":
-    discard await testToken.mint(accounts[0], 100.u256)
+      check (await token.balanceOf(accounts[0])) == 50.u256
+      check (await token.balanceOf(accounts[1])) == 50.u256
 
-    check (await token.allowance(accounts[0], accounts[1])) == 0.u256
-    check (await token.balanceOf(accounts[0])) == 100.u256
-    check (await token.balanceOf(accounts[1])) == 0.u256
+    test "approve tokens":
+      discard await testToken.mint(accounts[0], 100.u256)
 
-    await token.approve(accounts[1], 50.u256)
+      check (await token.allowance(accounts[0], accounts[1])) == 0.u256
+      check (await token.balanceOf(accounts[0])) == 100.u256
+      check (await token.balanceOf(accounts[1])) == 0.u256
 
-    check (await token.allowance(accounts[0], accounts[1])) == 50.u256
-    check (await token.balanceOf(accounts[0])) == 100.u256
-    check (await token.balanceOf(accounts[1])) == 0.u256
+      await token.approve(accounts[1], 50.u256)
 
-  test "transferFrom tokens":
-    let senderAccount = accounts[0]
-    let receiverAccount = accounts[1]
-    let receiverAccountSigner = provider.getSigner(receiverAccount)
+      check (await token.allowance(accounts[0], accounts[1])) == 50.u256
+      check (await token.balanceOf(accounts[0])) == 100.u256
+      check (await token.balanceOf(accounts[1])) == 0.u256
 
-    check (await token.balanceOf(senderAccount)) == 0.u256
-    check (await token.allowance(senderAccount, receiverAccount)) == 0.u256
+    test "transferFrom tokens":
+      let senderAccount = accounts[0]
+      let receiverAccount = accounts[1]
+      let receiverAccountSigner = provider.getSigner(receiverAccount)
 
-    discard await testToken.mint(senderAccount, 100.u256)
+      check (await token.balanceOf(senderAccount)) == 0.u256
+      check (await token.allowance(senderAccount, receiverAccount)) == 0.u256
 
-    check (await token.totalSupply()) == 100.u256
-    check (await token.balanceOf(senderAccount)) == 100.u256
-    check (await token.balanceOf(receiverAccount)) == 0.u256
+      discard await testToken.mint(senderAccount, 100.u256)
 
-    await token.approve(receiverAccount, 50.u256)
+      check (await token.totalSupply()) == 100.u256
+      check (await token.balanceOf(senderAccount)) == 100.u256
+      check (await token.balanceOf(receiverAccount)) == 0.u256
 
-    check (await token.allowance(senderAccount, receiverAccount)) == 50.u256
-    check (await token.balanceOf(senderAccount)) == 100.u256
-    check (await token.balanceOf(receiverAccount)) == 0.u256
+      await token.approve(receiverAccount, 50.u256)
 
-    await token.connect(receiverAccountSigner).transferFrom(senderAccount, receiverAccount, 50.u256)
+      check (await token.allowance(senderAccount, receiverAccount)) == 50.u256
+      check (await token.balanceOf(senderAccount)) == 100.u256
+      check (await token.balanceOf(receiverAccount)) == 0.u256
 
-    check (await token.balanceOf(senderAccount)) == 50.u256
-    check (await token.balanceOf(receiverAccount)) == 50.u256
-    check (await token.allowance(senderAccount, receiverAccount)) == 0.u256
+      await token.connect(receiverAccountSigner).transferFrom(senderAccount, receiverAccount, 50.u256)
+
+      check (await token.balanceOf(senderAccount)) == 50.u256
+      check (await token.balanceOf(receiverAccount)) == 50.u256
+      check (await token.allowance(senderAccount, receiverAccount)) == 0.u256
 

--- a/testmodule/testErc20.nim
+++ b/testmodule/testErc20.nim
@@ -33,6 +33,7 @@ for url in ["ws://localhost:8545", "http://localhost:8545"]:
 
     teardown:
       discard await provider.send("evm_revert", @[snapshot])
+      await provider.close()
 
     test "retrieves basic information":
       check (await token.name()) == "TestToken"

--- a/testmodule/testProviders.nim
+++ b/testmodule/testProviders.nim
@@ -1,0 +1,3 @@
+import ./providers/testJsonRpc
+
+{.warning[UnusedImport]:off.}

--- a/testmodule/testReturns.nim
+++ b/testmodule/testReturns.nim
@@ -21,6 +21,7 @@ suite "Contract return values":
 
   teardown:
     discard await provider.send("evm_revert", @[snapshot])
+    await provider.close()
 
   test "handles static size structs":
     proc getStatic(contract: TestReturns): Static {.contract, pure.}

--- a/testmodule/testReturns.nim
+++ b/testmodule/testReturns.nim
@@ -14,7 +14,7 @@ suite "Contract return values":
   var snapshot: JsonNode
 
   setup:
-    provider = JsonRpcProvider.new("ws://localhost:8545")
+    provider = JsonRpcProvider.new()
     snapshot = await provider.send("evm_snapshot")
     let deployment = readDeployment()
     contract = TestReturns.new(!deployment.address(TestReturns), provider)

--- a/testmodule/testTesting.nim
+++ b/testmodule/testTesting.nim
@@ -88,6 +88,7 @@ suite "Testing helpers - provider":
 
   teardown:
     discard await provider.send("evm_revert", @[snapshot])
+    await provider.close()
 
   test "revert works with provider":
     check await helpersContract.revertsWith(revertReason).reverts(revertReason)

--- a/testmodule/testWallet.nim
+++ b/testmodule/testWallet.nim
@@ -20,9 +20,10 @@ suite "Wallet":
   setup:
     provider = JsonRpcProvider.new()
     snapshot = await provider.send("evm_snapshot")
-  
+
   teardown:
     discard await provider.send("evm_revert", @[snapshot])
+    await provider.close()
 
   test "Can create Wallet with private key":
     discard Wallet.new(pk1)
@@ -114,7 +115,7 @@ suite "Wallet":
       gasLimit: some 22_000.u256)
     let testToken = Erc20.new(wallet.address, wallet)
     await testToken.transfer(wallet.address, 24.u256, overrides)
-  
+
   test "Can call state-changing function automatically EIP1559":
     #TODO add actual token contract, not random address. Should work regardless
     let wallet = Wallet.new(pk_with_funds, provider)


### PR DESCRIPTION
Subscriptions were already supported for websocket connections. This PR adds support for subscriptions on regular http connections through polling.