### PR TITLE
Fix EIP-155 signatures

### DIFF
--- a/ethers/transaction.nim
+++ b/ethers/transaction.nim
@@ -5,6 +5,7 @@ type Transaction* = object
   sender*: ?Address
   to*: Address
   data*: seq[byte]
+  value*: UInt256
   nonce*: ?UInt256
   chainId*: ?UInt256
   gasPrice*: ?UInt256
@@ -17,6 +18,7 @@ func `$`*(transaction: Transaction): string =
   if sender =? transaction.sender:
     result &= "from: " & $sender & ", "
   result &= "to: " & $transaction.to & ", "
+  result &= "value: " & $transaction.value & ", "
   result &= "data: 0x" & $transaction.data.toHex
   if nonce =? transaction.nonce:
     result &= ", nonce: 0x" & $nonce.toHex

--- a/ethers/wallet.nim
+++ b/ethers/wallet.nim
@@ -58,6 +58,10 @@ method getAddress(wallet: Wallet): Future[Address] {.async.} =
   return wallet.address
 
 proc signTransaction(tr: var SignableTransaction, pk: PrivateKey) =
+  # Temporary V value, used to signal to the hashing function the
+  # chain id that we'd like to use for an EIP-155 signature
+  tr.V = int64(uint64(tr.chainId)) * 2 + 35
+
   let h = tr.txHashNoSignature
   let s = sign(pk, SkMessage(h.data))
 
@@ -69,8 +73,7 @@ proc signTransaction(tr: var SignableTransaction, pk: PrivateKey) =
 
   case tr.txType:
   of TxLegacy:
-    #tr.V = int64(v) + int64(tr.chainId)*2 + 35  #TODO does not work, not sure why. Sending the tx results in error of too little funds. Maybe something wrong with signature and a wrong sender gets encoded?
-    tr.V = int64(v) + 27
+    tr.V = int64(v) + int64(uint64(tr.chainId))*2 + 35
   of TxEip1559:
     tr.V = int64(v)
   else:

--- a/ethers/wallet.nim
+++ b/ethers/wallet.nim
@@ -97,6 +97,7 @@ proc signTransaction*(wallet: Wallet, tx: tx.Transaction): Future[seq[byte]] {.a
 
   s.chainId = ChainId(chainId.truncate(uint64))
   s.gasLimit = GasInt(gasLimit.truncate(uint64))
+  s.value = tx.value
   s.nonce = nonce.truncate(uint64)
   s.to = some EthAddress(tx.to)
   s.payload = tx.data

--- a/ethers/wallet.nim
+++ b/ethers/wallet.nim
@@ -1,11 +1,9 @@
 import eth/keys
-import eth/rlp
-import eth/common
-import eth/common/transaction as ct
 import ./provider
-import ./transaction as tx
+import ./transaction
 import ./signer
 import ./wallet/error
+import ./wallet/signing
 
 export keys
 export WalletError
@@ -16,8 +14,6 @@ proc getRng: ref HmacDrbgContext =
   if rng.isNil:
     rng = newRng()
   rng
-
-type SignableTransaction = common.Transaction
 
 type Wallet* = ref object of Signer
   privateKey*: PrivateKey
@@ -58,61 +54,13 @@ method provider*(wallet: Wallet): Provider =
 method getAddress(wallet: Wallet): Future[Address] {.async.} =
   return wallet.address
 
-proc signTransaction(tr: var SignableTransaction, pk: PrivateKey) =
-  # Temporary V value, used to signal to the hashing function the
-  # chain id that we'd like to use for an EIP-155 signature
-  tr.V = int64(uint64(tr.chainId)) * 2 + 35
-
-  let h = tr.txHashNoSignature
-  let s = sign(pk, SkMessage(h.data))
-
-  let r = toRaw(s)
-  let v = r[64]
-
-  tr.R = fromBytesBE(UInt256, r.toOpenArray(0, 31))
-  tr.S = fromBytesBE(UInt256, r.toOpenArray(32, 63))
-
-  case tr.txType:
-  of TxLegacy:
-    tr.V = int64(v) + int64(uint64(tr.chainId))*2 + 35
-  of TxEip1559:
-    tr.V = int64(v)
-  else:
-    raiseWalletError "Transaction type not supported"
-
-proc signTransaction*(wallet: Wallet, tx: tx.Transaction): Future[seq[byte]] {.async.} =
-  if sender =? tx.sender and sender != wallet.address:
+proc signTransaction*(wallet: Wallet,
+                      transaction: Transaction): Future[seq[byte]] {.async.} =
+  if sender =? transaction.sender and sender != wallet.address:
     raiseWalletError "from address mismatch"
 
-  without nonce =? tx.nonce and chainId =? tx.chainId and gasLimit =? tx.gasLimit:
-    raiseWalletError "Transaction is not properly populated"
+  return wallet.privateKey.sign(transaction)
 
-  var s: SignableTransaction
-
-  if maxFee =? tx.maxFee and maxPriorityFee =? tx.maxPriorityFee:
-    s.txType = TxEip1559
-    s.maxFee = GasInt(maxFee.truncate(uint64))
-    s.maxPriorityFee = GasInt(maxPriorityFee.truncate(uint64))
-  elif gasPrice =? tx.gasPrice:
-    s.txType = TxLegacy
-    s.gasPrice = GasInt(gasPrice.truncate(uint64))
-  else:
-    raiseWalletError "Transaction is not properly populated"
-
-  s.chainId = ChainId(chainId.truncate(uint64))
-  s.gasLimit = GasInt(gasLimit.truncate(uint64))
-  s.value = tx.value
-  s.nonce = nonce.truncate(uint64)
-  s.to = some EthAddress(tx.to)
-  s.payload = tx.data
-  signTransaction(s, wallet.privateKey)
-
-  return rlp.encode(s)
-
-method sendTransaction*(wallet: Wallet, tx: tx.Transaction): Future[TransactionResponse] {.async.} =
-  let rawTX = await signTransaction(wallet, tx)
-  return await provider(wallet).sendTransaction(rawTX)
-
-#TODO add functionality to sign messages
-
-#TODO add functionality to create wallets from Mnemoniks or Keystores
+method sendTransaction*(wallet: Wallet, transaction: Transaction): Future[TransactionResponse] {.async.} =
+  let signed = await signTransaction(wallet, transaction)
+  return await provider(wallet).sendTransaction(signed)

--- a/ethers/wallet/error.nim
+++ b/ethers/wallet/error.nim
@@ -1,0 +1,7 @@
+import ../basics
+
+type
+  WalletError* = object of EthersError
+
+func raiseWalletError*(message: string) =
+  raise newException(WalletError, message)

--- a/ethers/wallet/signing.nim
+++ b/ethers/wallet/signing.nim
@@ -1,0 +1,64 @@
+import pkg/eth/keys
+import pkg/eth/rlp
+import pkg/eth/common/transaction as eth
+import ../basics
+import ../transaction as ethers
+import ./error
+
+type
+  Transaction = ethers.Transaction
+  SignableTransaction = eth.Transaction
+
+func toSignableTransaction(transaction: Transaction): SignableTransaction =
+  var signable: SignableTransaction
+
+  without nonce =? transaction.nonce:
+    raiseWalletError "missing nonce"
+
+  without chainId =? transaction.chainId:
+    raiseWalletError "missing chain id"
+
+  without gasLimit =? transaction.gasLimit:
+    raiseWalletError "missing gas limit"
+
+  signable.nonce = nonce.truncate(uint64)
+  signable.chainId = ChainId(chainId.truncate(uint64))
+  signable.gasLimit = GasInt(gasLimit.truncate(uint64))
+  signable.to = some EthAddress(transaction.to)
+  signable.value = transaction.value
+  signable.payload = transaction.data
+
+  if maxFee =? transaction.maxFee and
+     maxPriorityFee =? transaction.maxPriorityFee:
+    signable.txType = TxEip1559
+    signable.maxFee = GasInt(maxFee.truncate(uint64))
+    signable.maxPriorityFee = GasInt(maxPriorityFee.truncate(uint64))
+  elif gasPrice =? transaction.gasPrice:
+    signable.txType = TxLegacy
+    signable.gasPrice = GasInt(gasPrice.truncate(uint64))
+  else:
+    raiseWalletError "missing gas price"
+
+  signable
+
+func sign(key: PrivateKey, transaction: SignableTransaction): seq[byte] =
+  var transaction = transaction
+
+  # Temporary V value, used to signal to the hashing function
+  # that we'd like to use an EIP-155 signature
+  transaction.V = int64(uint64(transaction.chainId)) * 2 + 35
+
+  let hash = transaction.txHashNoSignature().data
+  let signature = key.sign(SkMessage(hash)).toRaw()
+
+  transaction.R = UInt256.fromBytesBE(signature[0..<32])
+  transaction.S = UInt256.fromBytesBE(signature[32..<64])
+  transaction.V = int64(signature[64])
+
+  if transaction.txType == TxLegacy:
+    transaction.V += int64(uint64(transaction.chainId)) * 2 + 35
+
+  rlp.encode(transaction)
+
+func sign*(key: PrivateKey, transaction: Transaction): seq[byte] =
+  key.sign(transaction.toSignableTransaction())

--- a/testmodule/testWallet.nim
+++ b/testmodule/testWallet.nim
@@ -56,29 +56,19 @@ suite "Wallet":
     check $wallet.address == "0x328809bc894f92807417d2dad6b7c998c1afdac6"
 
   test "Can sign manually created transaction":
-    let wallet = Wallet.new(pk1)
-    let tx = Transaction(
-      to: wallet.address,
-      nonce: some 0.u256,
-      chainId: some 31337.u256,
-      gasPrice: some 1_000_000_000.u256,
-      gasLimit: some 21_000.u256,
+    # Example from EIP-155
+    let wallet = Wallet.new("0x4646464646464646464646464646464646464646464646464646464646464646")
+    let transaction = Transaction(
+      to: !Address.init("0x3535353535353535353535353535353535353535"),
+      nonce: some 9.u256,
+      chainId: some 1.u256,
+      gasPrice: some 20 * 10.u256.pow(9),
+      gasLimit: some 21000.u256,
+      value: 10.u256.pow(18),
+      data: @[]
     )
-    let signedTx = await wallet.signTransaction(tx)
-    check signedTx.toHex == "f86380843b9aca0082520894328809bc894f92807417d2dad6b7c998c1afdac680801ba04ae9b24cba72103bb30a1e91c016796fc2bf2d46d2b75ca80211fae0337c3c03a05e3c81ce9944a07f18b65142a1847c5b72f993c8e7c28d5d4360ff36a2fed049"
-
-  test "Can sign manually created contract call":
-    let wallet = Wallet.new(pk1)
-    let tx = Transaction(
-      to: wallet.address,
-      data: @[24.byte, 22, 13, 221], # Arbitrary Calldata for totalsupply()
-      nonce: some 0.u256,
-      chainId: some 31337.u256,
-      gasPrice: some 1_000_000_000.u256,
-      gasLimit: some 21_000.u256,
-    )
-    let signedTx = await wallet.signTransaction(tx)
-    check signedTx.toHex == "f86780843b9aca0082520894328809bc894f92807417d2dad6b7c998c1afdac6808418160ddd1ca029261fc74ffbbb5ce3d0a3b6eac9726f05d8a849e0f1535722e057bdd83b9659a044f857852bd8b7bb8c0c0a5a61c2c56fce42edacab73f42301b509edb7600ff1"
+    let signed = await wallet.signTransaction(transaction)
+    check signed.toHex == "f86c098504a817c800825208943535353535353535353535353535353535353535880de0b6b3a76400008025a028ef61340bd939bc2195fe537567866003e1a15d3c71ff63e1590620aa636276a067cbe9d8997f761aecb703304b3800ccf555c9f3dc64214b297fb1966a3b6d83"
 
   test "Can sign manually created tx with EIP1559":
     let wallet = Wallet.new(pk1)
@@ -104,7 +94,7 @@ suite "Wallet":
     )
     let signedTx = await wallet.signTransaction(tx)
     let txHash = await provider.sendTransaction(signedTx)
-    check txHash.hash == TransactionHash([167.byte, 105, 79, 222, 144, 123, 214, 138, 4, 199, 124, 181, 35, 236, 79, 93, 84, 4, 85, 172, 40, 50, 189, 187, 219, 6, 172, 98, 243, 196, 93, 64])
+    check txHash.hash != TransactionHash.default
 
   test "Can call state-changing function automatically":
     #TODO add actual token contract, not random address. Should work regardless


### PR DESCRIPTION
Wallet now signs transactions according to EIP-155, which includes the chain id in the signature.
Includes a refactor of the wallet signing code.