### PR TITLE
Allow ERC20 functions to be confirmed

### DIFF
--- a/ethers/erc20.nim
+++ b/ethers/erc20.nim
@@ -46,17 +46,17 @@ method allowance*(token: Erc20Token,
 
 method transfer*(token: Erc20Token,
                  recipient: Address,
-                 amount: UInt256) {.base, contract.}
+                 amount: UInt256): ?TransactionResponse {.base, contract.}
   ## Moves `amount` tokens from the caller's account to `recipient`.
 
 method approve*(token: Erc20Token,
                 spender: Address,
-                amount: UInt256) {.base, contract.}
+                amount: UInt256): ?TransactionResponse {.base, contract.}
   ## Sets `amount` as the allowance of `spender` over the caller's tokens.
 
 method transferFrom*(token: Erc20Token,
                      spender: Address,
                      recipient: Address,
-                     amount: UInt256) {.base, contract.}
+                     amount: UInt256): ?TransactionResponse {.base, contract.}
   ## Moves `amount` tokens from `from` to `to` using the allowance
   ## mechanism. `amount` is then deducted from the caller's allowance.

--- a/ethers/erc20.nim
+++ b/ethers/erc20.nim
@@ -17,36 +17,46 @@ type
     spender* {.indexed.}: Address
     value*: UInt256
 
-method name*(erc20: Erc20Token): string {.base, contract, view.}
-## Returns the name of the token.
+method name*(token: Erc20Token): string {.base, contract, view.}
+  ## Returns the name of the token.
 
 method symbol*(token: Erc20Token): string {.base, contract, view.}
-## Returns the symbol of the token, usually a shorter version of the name.
+  ## Returns the symbol of the token, usually a shorter version of the name.
 
 method decimals*(token: Erc20Token): uint8 {.base, contract, view.}
-## Returns the number of decimals used to get its user representation.
-## For example, if `decimals` equals `2`, a balance of `505` tokens should
-## be displayed to a user as `5.05` (`505 / 10 ** 2`).
+  ## Returns the number of decimals used to get its user representation.
+  ## For example, if `decimals` equals `2`, a balance of `505` tokens should
+  ## be displayed to a user as `5.05` (`505 / 10 ** 2`).
 
-method totalSupply*(erc20: Erc20Token): UInt256 {.base, contract, view.}
-## Returns the amount of tokens in existence.
+method totalSupply*(token: Erc20Token): UInt256 {.base, contract, view.}
+  ## Returns the amount of tokens in existence.
 
-method balanceOf*(erc20: Erc20Token, account: Address): UInt256 {.base, contract, view.}
-## Returns the amount of tokens owned by `account`.
+method balanceOf*(token: Erc20Token,
+                  account: Address): UInt256 {.base, contract, view.}
+  ## Returns the amount of tokens owned by `account`.
 
-method allowance*(erc20: Erc20Token, owner, spender: Address): UInt256 {.base, contract, view.}
-## Returns the remaining number of tokens that `spender` will be allowed
-## to spend on behalf of `owner` through {transferFrom}. This is zero by default.
-##
-## This value changes when {approve} or {transferFrom} are called.
+method allowance*(token: Erc20Token,
+                  owner: Address,
+                  spender: Address): UInt256 {.base, contract, view.}
+  ## Returns the remaining number of tokens that `spender` will be allowed
+  ## to spend on behalf of `owner` through {transferFrom}. This is zero by
+  ## default.
+  ##
+  ## This value changes when {approve} or {transferFrom} are called.
 
-method transfer*(erc20: Erc20Token, recipient: Address, amount: UInt256) {.base, contract.}
-## Moves `amount` tokens from the caller's account to `recipient`.
+method transfer*(token: Erc20Token,
+                 recipient: Address,
+                 amount: UInt256) {.base, contract.}
+  ## Moves `amount` tokens from the caller's account to `recipient`.
 
-method approve*(token: Erc20Token, spender: Address, amount: UInt256) {.base, contract.}
-## Sets `amount` as the allowance of `spender` over the caller's tokens.
+method approve*(token: Erc20Token,
+                spender: Address,
+                amount: UInt256) {.base, contract.}
+  ## Sets `amount` as the allowance of `spender` over the caller's tokens.
 
-method transferFrom*(erc20: Erc20Token, spender: Address, recipient: Address, amount: UInt256) {.base, contract.}
-## Moves `amount` tokens from `from` to `to` using the allowance
-## mechanism. `amount` is then deducted from the caller's allowance.
-
+method transferFrom*(token: Erc20Token,
+                     spender: Address,
+                     recipient: Address,
+                     amount: UInt256) {.base, contract.}
+  ## Moves `amount` tokens from `from` to `to` using the allowance
+  ## mechanism. `amount` is then deducted from the caller's allowance.

--- a/testmodule/testContracts.nim
+++ b/testmodule/testContracts.nim
@@ -9,7 +9,6 @@ import ./miner
 import ./mocks
 
 type
-
   TestToken = ref object of Erc20Token
 
 method mint(token: TestToken, holder: Address, amount: UInt256): ?TransactionResponse {.base, contract.}
@@ -108,8 +107,8 @@ for url in ["ws://localhost:8545", "http://localhost:8545"]:
       let signer0 = provider.getSigner(accounts[0])
       let signer1 = provider.getSigner(accounts[1])
       discard await token.connect(signer0).mint(accounts[0], 100.u256)
-      await token.connect(signer0).transfer(accounts[1], 50.u256)
-      await token.connect(signer1).transfer(accounts[2], 25.u256)
+      discard await token.connect(signer0).transfer(accounts[1], 50.u256)
+      discard await token.connect(signer1).transfer(accounts[2], 25.u256)
       check (await token.connect(provider).balanceOf(accounts[0])) == 50.u256
       check (await token.connect(provider).balanceOf(accounts[1])) == 25.u256
       check (await token.connect(provider).balanceOf(accounts[2])) == 25.u256
@@ -150,8 +149,8 @@ for url in ["ws://localhost:8545", "http://localhost:8545"]:
 
       let subscription = await token.subscribe(Transfer, handleTransfer)
       discard await token.connect(signer0).mint(accounts[0], 100.u256)
-      await token.connect(signer0).transfer(accounts[1], 50.u256)
-      await token.connect(signer1).transfer(accounts[2], 25.u256)
+      discard await token.connect(signer0).transfer(accounts[1], 50.u256)
+      discard await token.connect(signer1).transfer(accounts[2], 25.u256)
 
       check eventually transfers == @[
         Transfer(receiver: accounts[0], value: 100.u256),
@@ -175,7 +174,7 @@ for url in ["ws://localhost:8545", "http://localhost:8545"]:
       check eventually transfers.len == 1
       await subscription.unsubscribe()
 
-      await token.connect(signer0).transfer(accounts[1], 50.u256)
+      discard await token.connect(signer0).transfer(accounts[1], 50.u256)
       await sleepAsync(100.millis)
 
       check transfers.len == 1

--- a/testmodule/testErc20.nim
+++ b/testmodule/testErc20.nim
@@ -51,7 +51,7 @@ for url in ["ws://localhost:8545", "http://localhost:8545"]:
       check (await token.balanceOf(accounts[0])) == 100.u256
       check (await token.balanceOf(accounts[1])) == 0.u256
 
-      await token.transfer(accounts[1], 50.u256)
+      discard await token.transfer(accounts[1], 50.u256)
 
       check (await token.balanceOf(accounts[0])) == 50.u256
       check (await token.balanceOf(accounts[1])) == 50.u256
@@ -63,7 +63,7 @@ for url in ["ws://localhost:8545", "http://localhost:8545"]:
       check (await token.balanceOf(accounts[0])) == 100.u256
       check (await token.balanceOf(accounts[1])) == 0.u256
 
-      await token.approve(accounts[1], 50.u256)
+      discard await token.approve(accounts[1], 50.u256)
 
       check (await token.allowance(accounts[0], accounts[1])) == 50.u256
       check (await token.balanceOf(accounts[0])) == 100.u256
@@ -83,13 +83,13 @@ for url in ["ws://localhost:8545", "http://localhost:8545"]:
       check (await token.balanceOf(senderAccount)) == 100.u256
       check (await token.balanceOf(receiverAccount)) == 0.u256
 
-      await token.approve(receiverAccount, 50.u256)
+      discard await token.approve(receiverAccount, 50.u256)
 
       check (await token.allowance(senderAccount, receiverAccount)) == 50.u256
       check (await token.balanceOf(senderAccount)) == 100.u256
       check (await token.balanceOf(receiverAccount)) == 0.u256
 
-      await token.connect(receiverAccountSigner).transferFrom(senderAccount, receiverAccount, 50.u256)
+      discard await token.connect(receiverAccountSigner).transferFrom(senderAccount, receiverAccount, 50.u256)
 
       check (await token.balanceOf(senderAccount)) == 50.u256
       check (await token.balanceOf(receiverAccount)) == 50.u256


### PR DESCRIPTION
Adds a return value of `?TransactionResponse` to the ERC20 functions that trigger a transaction to be sent.
This allows for code that waits for a number of confirmations, e.g.:

    let receipt = await token.transfer(receiver, 42.u256).confirm(3)