### PR TITLE
Create wallet with PrivateKey

### DIFF
--- a/ethers/wallet.nim
+++ b/ethers/wallet.nim
@@ -24,17 +24,18 @@ type Wallet* = ref object of Signer
   address*: Address
   provider*: ?Provider
 
-proc new*(_: type Wallet, pk: string, provider: Provider): Wallet =
-  result = Wallet()
-  result.privateKey = PrivateKey.fromHex(pk).value
-  result.publicKey = result.privateKey.toPublicKey()
-  result.address = Address.init(result.publicKey.toCanonicalAddress())
-  result.provider = some provider
-proc new*(_: type Wallet, pk: string): Wallet =
-  result = Wallet()
-  result.privateKey = PrivateKey.fromHex(pk).value
-  result.publicKey = result.privateKey.toPublicKey()
-  result.address = Address.init(result.publicKey.toCanonicalAddress())
+proc new*(_: type Wallet, privateKey: PrivateKey): Wallet =
+  let publicKey = privateKey.toPublicKey()
+  let address = Address.init(publicKey.toCanonicalAddress())
+  Wallet(privateKey: privateKey, publicKey: publicKey, address: address)
+proc new*(_: type Wallet, privateKey: PrivateKey, provider: Provider): Wallet =
+  let wallet = Wallet.new(privateKey)
+  wallet.provider = some provider
+  wallet
+proc new*(_: type Wallet, privateKey: string): Wallet =
+  Wallet.new(PrivateKey.fromHex(privateKey).value)
+proc new*(_: type Wallet, privateKey: string, provider: Provider): Wallet =
+  Wallet.new(PrivateKey.fromHex(privateKey).value, provider)
 proc connect*(wallet: Wallet, provider: Provider) =
   wallet.provider = some provider
 proc createRandom*(_: type Wallet): Wallet =

--- a/testmodule/testWallet.nim
+++ b/testmodule/testWallet.nim
@@ -9,11 +9,6 @@ type Erc20* = ref object of Contract
 proc transfer*(erc20: Erc20, recipient: Address, amount: UInt256) {.contract.}
 
 suite "Wallet":
-
-  #TODO add more tests. I am not sure if I am testing everything currently
-  #TODO take close look at current signing tests. I am not 100% sure they are correct and work
-  #TODO add setup/teardown if required. Currently doing all nonces manually
-
   var provider: JsonRpcProvider
   var snapshot: JsonNode
 

--- a/testmodule/testWallet.nim
+++ b/testmodule/testWallet.nim
@@ -27,6 +27,7 @@ suite "Wallet":
 
   test "Can create Wallet with private key":
     discard Wallet.new(pk1)
+    discard Wallet.new(PrivateKey.fromHex(pk1).value)
 
   test "Private key can start with 0x":
     discard Wallet.new("0x" & pk1)
@@ -34,6 +35,7 @@ suite "Wallet":
   test "Can create Wallet with provider":
     let provider = JsonRpcProvider.new()
     discard Wallet.new(pk1, provider)
+    discard Wallet.new(PrivateKey.fromHex(pk1).value)
 
   test "Can connect Wallet to provider":
     let wallet = Wallet.new(pk1)


### PR DESCRIPTION
Adds a constructor for `Wallet` that takes an instance of `PrivateKey`, instead of a string.