### PR TITLE
Query past contract events

### DIFF
--- a/ethers/provider.nim
+++ b/ethers/provider.nim
@@ -12,14 +12,19 @@ type
   Provider* = ref object of RootObj
   ProviderError* = object of EthersError
   Subscription* = ref object of RootObj
-  EventFilter* = object of RootObj
+  EventFilter* = ref object of RootObj
     address*: Address
     topics*: seq[Topic]
-  Filter* = object of EventFilter
-    fromBlock: BlockTag
-    toBlock: BlockTag
+  Filter* = ref object of EventFilter
+    fromBlock*: BlockTag
+    toBlock*: BlockTag
+  FilterByBlockHash* = ref object of EventFilter
+    blockHash*: BlockHash
   Log* = object
+    blockNumber*: UInt256
     data*: seq[byte]
+    logIndex*: UInt256
+    removed*: bool
     topics*: seq[Topic]
   TransactionHash* = array[32, byte]
   BlockHash* = array[32, byte]
@@ -85,7 +90,7 @@ method sendTransaction*(provider: Provider,
   doAssert false, "not implemented"
 
 method getLogs*(provider: Provider,
-                filter: Filter): Future[seq[Log]] {.base.} =
+                filter: EventFilter): Future[seq[Log]] {.base.} =
   doAssert false, "not implemented"
 
 method estimateGas*(provider: Provider,

--- a/ethers/provider.nim
+++ b/ethers/provider.nim
@@ -12,9 +12,12 @@ type
   Provider* = ref object of RootObj
   ProviderError* = object of EthersError
   Subscription* = ref object of RootObj
-  Filter* = object
+  EventFilter* = object of RootObj
     address*: Address
     topics*: seq[Topic]
+  Filter* = object of EventFilter
+    fromBlock: BlockTag
+    toBlock: BlockTag
   Log* = object
     data*: seq[byte]
     topics*: seq[Topic]
@@ -81,6 +84,10 @@ method sendTransaction*(provider: Provider,
                        Future[TransactionResponse] {.base.} =
   doAssert false, "not implemented"
 
+method getLogs*(provider: Provider,
+                filter: Filter): Future[seq[Log]] {.base.} =
+  doAssert false, "not implemented"
+
 method estimateGas*(provider: Provider,
                     transaction: Transaction): Future[UInt256] {.base.} =
   doAssert false, "not implemented"
@@ -89,7 +96,7 @@ method getChainId*(provider: Provider): Future[UInt256] {.base.} =
   doAssert false, "not implemented"
 
 method subscribe*(provider: Provider,
-                  filter: Filter,
+                  filter: EventFilter,
                   callback: LogHandler):
                  Future[Subscription] {.base.} =
   doAssert false, "not implemented"

--- a/ethers/providers/jsonrpc.nim
+++ b/ethers/providers/jsonrpc.nim
@@ -138,11 +138,18 @@ method getTransactionCount*(provider: JsonRpcProvider,
     return await client.eth_getTransactionCount(address, blockTag)
 
 method getTransactionReceipt*(provider: JsonRpcProvider,
-                            txHash: TransactionHash):
-                           Future[?TransactionReceipt] {.async.} =
+                              txHash: TransactionHash):
+                             Future[?TransactionReceipt] {.async.} =
   convertError:
     let client = await provider.client
     return await client.eth_getTransactionReceipt(txHash)
+
+method getLogs*(provider: JsonRpcProvider,
+                filter: Filter):
+               Future[?seq[Log]] {.async.} =
+  convertError:
+    let client = await provider.client
+    return await client.eth_getLogs(filter)
 
 method estimateGas*(provider: JsonRpcProvider,
                     transaction: Transaction): Future[UInt256] {.async.} =

--- a/ethers/providers/jsonrpc/signatures.nim
+++ b/ethers/providers/jsonrpc/signatures.nim
@@ -4,7 +4,7 @@ proc eth_blockNumber: UInt256
 proc eth_call(transaction: Transaction, blockTag: BlockTag): seq[byte]
 proc eth_gasPrice(): UInt256
 proc eth_getBlockByNumber(blockTag: BlockTag, includeTransactions: bool): ?Block
-proc eth_getLogs(filter: Filter): ?seq[Log]
+proc eth_getLogs(filter: EventFilter | Filter | FilterByBlockHash): JsonNode
 proc eth_getBlockByHash(hash: BlockHash, includeTransactions: bool): ?Block
 proc eth_getTransactionCount(address: Address, blockTag: BlockTag): UInt256
 proc eth_estimateGas(transaction: Transaction): UInt256
@@ -17,6 +17,6 @@ proc eth_subscribe(name: string, filter: EventFilter): JsonNode
 proc eth_subscribe(name: string): JsonNode
 proc eth_unsubscribe(id: JsonNode): bool
 proc eth_newBlockFilter(): JsonNode
-proc eth_newFilter(filter: Filter): JsonNode
+proc eth_newFilter(filter: EventFilter): JsonNode
 proc eth_getFilterChanges(id: JsonNode): JsonNode
 proc eth_uninstallFilter(id: JsonNode): bool

--- a/ethers/providers/jsonrpc/signatures.nim
+++ b/ethers/providers/jsonrpc/signatures.nim
@@ -4,6 +4,7 @@ proc eth_blockNumber: UInt256
 proc eth_call(transaction: Transaction, blockTag: BlockTag): seq[byte]
 proc eth_gasPrice(): UInt256
 proc eth_getBlockByNumber(blockTag: BlockTag, includeTransactions: bool): ?Block
+proc eth_getLogs(filter: Filter): ?seq[Log]
 proc eth_getBlockByHash(hash: BlockHash, includeTransactions: bool): ?Block
 proc eth_getTransactionCount(address: Address, blockTag: BlockTag): UInt256
 proc eth_estimateGas(transaction: Transaction): UInt256
@@ -12,7 +13,7 @@ proc eth_sendTransaction(transaction: Transaction): TransactionHash
 proc eth_sendRawTransaction(data: seq[byte]): TransactionHash
 proc eth_getTransactionReceipt(hash: TransactionHash): ?TransactionReceipt
 proc eth_sign(account: Address, message: seq[byte]): seq[byte]
-proc eth_subscribe(name: string, filter: Filter): JsonNode
+proc eth_subscribe(name: string, filter: EventFilter): JsonNode
 proc eth_subscribe(name: string): JsonNode
 proc eth_unsubscribe(id: JsonNode): bool
 proc eth_newBlockFilter(): JsonNode

--- a/ethers/providers/jsonrpc/subscriptions.nim
+++ b/ethers/providers/jsonrpc/subscriptions.nim
@@ -21,7 +21,7 @@ method subscribeBlocks*(subscriptions: JsonRpcSubscriptions,
   raiseAssert "not implemented"
 
 method subscribeLogs*(subscriptions: JsonRpcSubscriptions,
-                      filter: Filter,
+                      filter: EventFilter,
                       onLog: LogHandler):
                      Future[JsonNode]
                      {.async, base.} =
@@ -74,7 +74,7 @@ method subscribeBlocks(subscriptions: WebSocketSubscriptions,
   return id
 
 method subscribeLogs(subscriptions: WebSocketSubscriptions,
-                     filter: Filter,
+                     filter: EventFilter,
                      onLog: LogHandler):
                     Future[JsonNode]
                     {.async.} =
@@ -148,7 +148,7 @@ method subscribeBlocks(subscriptions: PollingSubscriptions,
   return id
 
 method subscribeLogs(subscriptions: PollingSubscriptions,
-                     filter: Filter,
+                     filter: EventFilter,
                      onLog: LogHandler):
                     Future[JsonNode]
                     {.async.} =

--- a/testmodule/testContracts.nim
+++ b/testmodule/testContracts.nim
@@ -213,11 +213,10 @@ for url in ["ws://localhost:8545", "http://localhost:8545"]:
 
       let currentBlock = await provider.getBlockNumber()
       let logs = await token.queryFilter(Transfer,
-                                         BlockTag.init(currentBlock - 3),
+                                         BlockTag.init(currentBlock - 1),
                                          BlockTag.latest)
 
-      check eventually logs == @[
-        Transfer(receiver: accounts[0], value: 100.u256),
+      check logs == @[
         Transfer(sender: accounts[0], receiver: accounts[1], value: 50.u256),
         Transfer(sender: accounts[1], receiver: accounts[2], value: 25.u256)
       ]
@@ -233,6 +232,6 @@ for url in ["ws://localhost:8545", "http://localhost:8545"]:
 
       let logs = await token.queryFilter(Transfer, !receipt.blockHash)
 
-      check eventually logs == @[
+      check logs == @[
         Transfer(receiver: accounts[0], value: 100.u256)
       ]

--- a/testmodule/testContracts.nim
+++ b/testmodule/testContracts.nim
@@ -189,7 +189,7 @@ for url in ["ws://localhost:8545", "http://localhost:8545"]:
       let receipt = await confirming
       check receipt.blockNumber.isSome
 
-    test "can query last block log":
+    test "can query last block event log":
 
       let signer0 = provider.getSigner(accounts[0])
       let signer1 = provider.getSigner(accounts[1])
@@ -204,7 +204,7 @@ for url in ["ws://localhost:8545", "http://localhost:8545"]:
         Transfer(sender: accounts[1], receiver: accounts[2], value: 25.u256)
       ]
 
-    test "can query past logs by specifying from and to blocks":
+    test "can query past event logs by specifying from and to blocks":
 
       let signer0 = provider.getSigner(accounts[0])
       let signer1 = provider.getSigner(accounts[1])
@@ -224,7 +224,7 @@ for url in ["ws://localhost:8545", "http://localhost:8545"]:
         Transfer(sender: accounts[1], receiver: accounts[2], value: 25.u256)
       ]
 
-    test "can query past logs by specifying a block hash":
+    test "can query past event logs by specifying a block hash":
 
       let signer0 = provider.getSigner(accounts[0])
 

--- a/testmodule/testContracts.nim
+++ b/testmodule/testContracts.nim
@@ -192,16 +192,14 @@ for url in ["ws://localhost:8545", "http://localhost:8545"]:
     test "can query last block event log":
 
       let signer0 = provider.getSigner(accounts[0])
-      let signer1 = provider.getSigner(accounts[1])
 
       discard await token.connect(signer0).mint(accounts[0], 100.u256)
-      await token.connect(signer0).transfer(accounts[1], 50.u256)
-      await token.connect(signer1).transfer(accounts[2], 25.u256)
+      discard await token.connect(signer0).transfer(accounts[1], 50.u256)
 
       let logs = await token.queryFilter(Transfer)
 
       check eventually logs == @[
-        Transfer(sender: accounts[1], receiver: accounts[2], value: 25.u256)
+        Transfer(sender: accounts[0], receiver: accounts[1], value: 50.u256)
       ]
 
     test "can query past event logs by specifying from and to blocks":
@@ -210,8 +208,8 @@ for url in ["ws://localhost:8545", "http://localhost:8545"]:
       let signer1 = provider.getSigner(accounts[1])
 
       discard await token.connect(signer0).mint(accounts[0], 100.u256)
-      await token.connect(signer0).transfer(accounts[1], 50.u256)
-      await token.connect(signer1).transfer(accounts[2], 25.u256)
+      discard await token.connect(signer0).transfer(accounts[1], 50.u256)
+      discard await token.connect(signer1).transfer(accounts[2], 25.u256)
 
       let currentBlock = await provider.getBlockNumber()
       let logs = await token.queryFilter(Transfer,
@@ -231,7 +229,7 @@ for url in ["ws://localhost:8545", "http://localhost:8545"]:
       let receipt = await token.connect(signer0)
                                .mint(accounts[0], 100.u256)
                                .confirm(1)
-      await token.connect(signer0).transfer(accounts[1], 50.u256)
+      discard await token.connect(signer0).transfer(accounts[1], 50.u256)
 
       let logs = await token.queryFilter(Transfer, !receipt.blockHash)
 

--- a/testmodule/testContracts.nim
+++ b/testmodule/testContracts.nim
@@ -188,3 +188,25 @@ for url in ["ws://localhost:8545", "http://localhost:8545"]:
       await provider.mineBlocks(2) # two additional blocks
       let receipt = await confirming
       check receipt.blockNumber.isSome
+
+    test "can query past logs":
+      var transfers: seq[Transfer]
+
+      proc handleTransfer(transfer: Transfer) =
+        transfers.add(transfer)
+
+      let signer0 = provider.getSigner(accounts[0])
+      let signer1 = provider.getSigner(accounts[1])
+
+      let subscription = await token.subscribe(Transfer, handleTransfer)
+      discard await token.connect(signer0).mint(accounts[0], 100.u256)
+      await token.connect(signer0).transfer(accounts[1], 50.u256)
+      await token.connect(signer1).transfer(accounts[2], 25.u256)
+
+      check eventually transfers == @[
+        Transfer(receiver: accounts[0], value: 100.u256),
+        Transfer(sender: accounts[0], receiver: accounts[1], value: 50.u256),
+        Transfer(sender: accounts[1], receiver: accounts[2], value: 25.u256)
+      ]
+
+      await subscription.unsubscribe()


### PR DESCRIPTION
Based on [ethers.js's `queryFilter`](https://github.com/ethers-io/ethers.js/blob/master/packages/contracts/src.ts/index.ts#L1039), allows querying of past contract events, by querying the logs for a contract's event topic.