### PR TITLE
fix: deserialize BlockTag from empty string

### DIFF
--- a/ethers/blocktag.nim
+++ b/ethers/blocktag.nim
@@ -34,3 +34,10 @@ func `$`*(blockTag: BlockTag): string =
     blockTag.stringValue
   of numberBlockTag:
     "0x" & blockTag.numberValue.toHex
+
+func `==`*(a, b: BlockTag): bool =
+  case a.kind
+    of stringBlockTag:
+      a.stringValue == b.stringValue
+    of numberBlockTag:
+      a.numberValue == b.numberValue

--- a/ethers/providers/jsonrpc/conversions.nim
+++ b/ethers/providers/jsonrpc/conversions.nim
@@ -81,7 +81,7 @@ func `%`*(tag: BlockTag): JsonNode =
 func fromJson*(_: type BlockTag, json: JsonNode): ?!BlockTag =
   expectJsonKind(BlockTag, JString, json)
   let jsonVal = json.getStr
-  if jsonVal[0..1].toLowerAscii == "0x":
+  if jsonVal.len >= 2 and jsonVal[0..1].toLowerAscii == "0x":
     without blkNum =? UInt256.fromHex(jsonVal).catch, error:
       return BlockTag.failure error.msg
     return success BlockTag.init(blkNum)

--- a/testmodule/providers/jsonrpc/testConversions.nim
+++ b/testmodule/providers/jsonrpc/testConversions.nim
@@ -223,3 +223,14 @@ suite "JSON Conversions":
       "gasPrice": 0x3b9aca07.u256,
       "gas": 0x52277.u256
     }
+
+  test "correctly deserializes BlockTag":
+    check !BlockTag.fromJson(newJString("earliest")) == BlockTag.earliest
+    check !BlockTag.fromJson(newJString("latest")) == BlockTag.latest
+    check !BlockTag.fromJson(newJString("pending")) == BlockTag.pending
+    check !BlockTag.fromJson(newJString("0x1")) == BlockTag.init(1.u256)
+
+  test "fails to deserialize BlockTag from an empty string":
+    let res = BlockTag.fromJson(newJString(""))
+    check res.error of SerializationError
+    check res.error.msg == "Failed to convert '\"\"' to BlockTag: must be one of 'earliest', 'latest', 'pending'"


### PR DESCRIPTION
Allows BlockTag to be deserialized from an empty string.