### PR TITLE
fix: nonce too high

### DIFF
--- a/ethers/contract.nim
+++ b/ethers/contract.nim
@@ -125,7 +125,7 @@ proc send(contract: Contract,
           function: string,
           parameters: tuple,
           overrides = TransactionOverrides()):
-         Future[?TransactionResponse] {.async.} =
+         Future[?TransactionResponse] {.async: (raises: [AsyncLockError]).} =
   if signer =? contract.signer:
 
     var params: seq[string] = @[]

--- a/ethers/contract.nim
+++ b/ethers/contract.nim
@@ -129,14 +129,10 @@ proc send(
 ): Future[?TransactionResponse] {.async: (raises: [AsyncLockError, CancelledError, CatchableError]).} =
 
   if signer =? contract.signer:
-    var params: seq[string] = @[]
-    for param in parameters.fields:
-      params.add $param
-
     withLock(signer):
       let transaction = createTransaction(contract, function, parameters, overrides)
       let populated = await signer.populateTransaction(transaction)
-      trace "sending contract transaction", function, params
+      trace "sending contract transaction", function, params = $parameters
       let txResp = await signer.sendTransaction(populated)
       return txResp.some
   else:

--- a/ethers/providers/jsonrpc.nim
+++ b/ethers/providers/jsonrpc.nim
@@ -327,8 +327,6 @@ method sendTransaction*(
   {.async: (raises:[SignerError, ProviderError]).} =
 
   convertError:
-    if nonce =? transaction.nonce:
-      signer.updateNonce(nonce)
     let
       client = await signer.provider.client
       hash = await client.eth_sendTransaction(transaction)

--- a/ethers/signers/wallet.nim
+++ b/ethers/signers/wallet.nim
@@ -86,6 +86,4 @@ method sendTransaction*(
   {.async: (raises:[SignerError, ProviderError]).} =
 
   let signed = await signTransaction(wallet, transaction)
-  if nonce =? transaction.nonce:
-    wallet.updateNonce(nonce)
   return await provider(wallet).sendTransaction(signed)

--- a/testmodule/providers/jsonrpc/testJsonRpcSigner.nim
+++ b/testmodule/providers/jsonrpc/testJsonRpcSigner.nim
@@ -84,24 +84,3 @@ suite "JsonRpcSigner":
     transaction.chainId = 0xdeadbeef.u256.some
     expect SignerError:
       discard await signer.populateTransaction(transaction)
-
-  test "concurrent populate calls increment nonce":
-    let signer = provider.getSigner()
-    let count = await signer.getTransactionCount(BlockTag.pending)
-    var transaction1 = Transaction.example
-    var transaction2 = Transaction.example
-    var transaction3 = Transaction.example
-
-    let populated = await allFinished(
-      signer.populateTransaction(transaction1),
-      signer.populateTransaction(transaction2),
-      signer.populateTransaction(transaction3)
-    )
-
-    transaction1 = await populated[0]
-    transaction2 = await populated[1]
-    transaction3 = await populated[2]
-
-    check !transaction1.nonce == count
-    check !transaction2.nonce == count + 1.u256
-    check !transaction3.nonce == count + 2.u256


### PR DESCRIPTION
Concurrent asynchronous population of transactions cause issues with nonces not being in sync with the transaction count for an account on chain. This was being mitigated by tracking a "last seen" nonce and locking inside of `populateTransaction` so that the nonce could be populated in a concurrent fashion. However, if there was an async cancellation before the transaction was sent, then the nonce would become out of sync. One solution was to decrease the nonce if a cancellation occurred. The other solution, in this PR, is simply to lock the populate and sendTransaction calls together, so that there will not be concurrent nonce discrepancies. This removes the need for "lastSeenNonce" and is overall more simple.

This issue was causing issues in Codex's testnet where slots were not being filled due to incorrect nonces and pending transactions.