### PR TITLE
fix: modify unsubscribe cleanup routine

### DIFF
--- a/ethers/providers/jsonrpc/subscriptions.nim
+++ b/ethers/providers/jsonrpc/subscriptions.nim
@@ -175,11 +175,8 @@ proc new*(_: type JsonRpcSubscriptions,
   subscriptions
 
 method close*(subscriptions: PollingSubscriptions) {.async.} =
-  echo "Cancelling subscription polling..."
   await subscriptions.polling.cancelAndWait()
-  echo "Calling Provider.close..."
   await procCall JsonRpcSubscriptions(subscriptions).close()
-  echo "Close done."
 
 method subscribeBlocks(subscriptions: PollingSubscriptions,
                        onBlock: BlockHandler):

--- a/ethers/providers/jsonrpc/subscriptions.nim
+++ b/ethers/providers/jsonrpc/subscriptions.nim
@@ -175,8 +175,11 @@ proc new*(_: type JsonRpcSubscriptions,
   subscriptions
 
 method close*(subscriptions: PollingSubscriptions) {.async.} =
+  echo "Cancelling subscription polling..."
   await subscriptions.polling.cancelAndWait()
+  echo "Calling Provider.close..."
   await procCall JsonRpcSubscriptions(subscriptions).close()
+  echo "Close done."
 
 method subscribeBlocks(subscriptions: PollingSubscriptions,
                        onBlock: BlockHandler):

--- a/ethers/providers/jsonrpc/subscriptions.nim
+++ b/ethers/providers/jsonrpc/subscriptions.nim
@@ -220,9 +220,10 @@ method unsubscribe*(subscriptions: PollingSubscriptions,
                   {.async.} =
   subscriptions.filters.del(id)
   subscriptions.callbacks.del(id)
+  let sub = subscriptions.subscriptionMapping[id]
   subscriptions.subscriptionMapping.del(id)
   try:
-    discard await subscriptions.client.eth_uninstallFilter(subscriptions.subscriptionMapping[id])
+    discard await subscriptions.client.eth_uninstallFilter(sub)
   except CancelledError as e:
     raise e
   except CatchableError as e:

--- a/testmodule/providers/jsonrpc/rpc_mock.nim
+++ b/testmodule/providers/jsonrpc/rpc_mock.nim
@@ -6,7 +6,7 @@ import std/tables
 import pkg/stew/byteutils
 import pkg/json_rpc/rpcserver except `%`, `%*`
 import pkg/json_rpc/errors
-
+import std/random
 
 type MockRpcHttpServer* = ref object
   filters*: Table[string, bool]
@@ -14,7 +14,10 @@ type MockRpcHttpServer* = ref object
   srv: RpcHttpServer
 
 proc new*(_: type MockRpcHttpServer): MockRpcHttpServer =
-  MockRpcHttpServer(filters: initTable[string, bool](), newFilterCounter: 0, srv: newRpcHttpServer(["127.0.0.1:65080"]))
+  let port = rand(65000..<66000)
+  let srv = newRpcHttpServer(["127.0.0.1:" & port])
+  let filters = initTable[string, bool]()
+  MockRpcHttpServer(filters: filters, newFilterCounter: 0, srv: srv)
 
 proc invalidateFilter*(server: MockRpcHttpServer, id: string) =
   server.filters[id] = false

--- a/testmodule/providers/jsonrpc/rpc_mock.nim
+++ b/testmodule/providers/jsonrpc/rpc_mock.nim
@@ -14,10 +14,7 @@ type MockRpcHttpServer* = ref object
   srv: RpcHttpServer
 
 proc new*(_: type MockRpcHttpServer): MockRpcHttpServer =
-  let port = rand(49152..65535)
-  let srv = newRpcHttpServer(["127.0.0.1:" & $port])
-  let filters = initTable[string, bool]()
-  MockRpcHttpServer(filters: filters, newFilterCounter: 0, srv: srv)
+  MockRpcHttpServer(filters: initTable[string, bool](), newFilterCounter: 0, srv: newRpcHttpServer(["127.0.0.1:0"]))
 
 proc invalidateFilter*(server: MockRpcHttpServer, id: string) =
   server.filters[id] = false

--- a/testmodule/providers/jsonrpc/rpc_mock.nim
+++ b/testmodule/providers/jsonrpc/rpc_mock.nim
@@ -15,7 +15,7 @@ type MockRpcHttpServer* = ref object
 
 proc new*(_: type MockRpcHttpServer): MockRpcHttpServer =
   let port = rand(65000..<66000)
-  let srv = newRpcHttpServer(["127.0.0.1:" & port])
+  let srv = newRpcHttpServer(["127.0.0.1:" & $port])
   let filters = initTable[string, bool]()
   MockRpcHttpServer(filters: filters, newFilterCounter: 0, srv: srv)
 

--- a/testmodule/providers/jsonrpc/rpc_mock.nim
+++ b/testmodule/providers/jsonrpc/rpc_mock.nim
@@ -14,7 +14,7 @@ type MockRpcHttpServer* = ref object
   srv: RpcHttpServer
 
 proc new*(_: type MockRpcHttpServer): MockRpcHttpServer =
-  let port = rand(65000..<66000)
+  let port = rand(49152..65535)
   let srv = newRpcHttpServer(["127.0.0.1:" & $port])
   let filters = initTable[string, bool]()
   MockRpcHttpServer(filters: filters, newFilterCounter: 0, srv: srv)

--- a/testmodule/providers/jsonrpc/rpc_mock.nim
+++ b/testmodule/providers/jsonrpc/rpc_mock.nim
@@ -14,7 +14,7 @@ type MockRpcHttpServer* = ref object
   srv: RpcHttpServer
 
 proc new*(_: type MockRpcHttpServer): MockRpcHttpServer =
-  MockRpcHttpServer(filters: initTable[string, bool](), newFilterCounter: 0, srv: newRpcHttpServer(["127.0.0.1:0"]))
+  MockRpcHttpServer(filters: initTable[string, bool](), newFilterCounter: 0, srv: newRpcHttpServer(["127.0.0.1:65080"]))
 
 proc invalidateFilter*(server: MockRpcHttpServer, id: string) =
   server.filters[id] = false

--- a/testmodule/providers/jsonrpc/testJsonRpcSubscriptions.nim
+++ b/testmodule/providers/jsonrpc/testJsonRpcSubscriptions.nim
@@ -128,18 +128,29 @@ suite "HTTP polling subscriptions - filter not found":
     await mockServer.stop()
 
   test "filter not found error recreates filter":
+    echo "1"
     let filter = EventFilter(address: Address.example, topics: @[array[32, byte].example])
+    echo "2"
     let emptyHandler = proc(log: Log) = discard
+    echo "3"
 
     check mockServer.newFilterCounter == 0
+    echo "4"
     let jsonId = await subscriptions.subscribeLogs(filter, emptyHandler)
+    echo "5"
     let id = string.fromJson(jsonId).tryGet
+    echo "6"
     check mockServer.newFilterCounter == 1
+    echo "7"
 
     await sleepAsync(50.millis)
+    echo "8"
     mockServer.invalidateFilter(id)
+    echo "9"
     await sleepAsync(50.millis)
+    echo "10"
     check mockServer.newFilterCounter == 2
+    echo "11"
 
   test "recreated filter can be still unsubscribed using the original id":
     let filter = EventFilter(address: Address.example, topics: @[array[32, byte].example])

--- a/testmodule/providers/jsonrpc/testJsonRpcSubscriptions.nim
+++ b/testmodule/providers/jsonrpc/testJsonRpcSubscriptions.nim
@@ -103,58 +103,34 @@ suite "HTTP polling subscriptions - filter not found":
   var mockServer: MockRpcHttpServer
 
   setup:
-    echo "Creating MockRpcHttpServer instance"
     mockServer = MockRpcHttpServer.new()
-    echo "Starting MockRpcHttpServer..."
     mockServer.start()
-    echo "Started MockRpcHttpServer"
 
-    echo "Creating new RpcHttpClient instance..."
     client = newRpcHttpClient()
-    echo "Connecting RpcHttpClient to MockRpcHttpServer..."
     await client.connect("http://" & $mockServer.localAddress()[0])
-    echo "Connected RpcHttpClient to MockRpcHttpServer"
 
-    echo "Creating new JsonRpcSubscriptions instance..."
     subscriptions = JsonRpcSubscriptions.new(client,
                                              pollingInterval = 100.millis)
-    echo "Starting JsonRpcSubscriptions..."
     subscriptions.start()
-    echo "Started JsonRpcSubscriptions"
 
   teardown:
-    echo "Closing subscriptions..."
     await subscriptions.close()
-    echo "Closing client..."
     await client.close()
-    echo "Stopping mock server..."
     await mockServer.stop()
-    echo "Stopped mock server"
 
   test "filter not found error recreates filter":
-    echo "1"
     let filter = EventFilter(address: Address.example, topics: @[array[32, byte].example])
-    echo "2"
     let emptyHandler = proc(log: Log) = discard
-    echo "3"
 
     check mockServer.newFilterCounter == 0
-    echo "4"
     let jsonId = await subscriptions.subscribeLogs(filter, emptyHandler)
-    echo "5"
     let id = string.fromJson(jsonId).tryGet
-    echo "6"
     check mockServer.newFilterCounter == 1
-    echo "7"
 
-    await sleepAsync(200.millis)
-    echo "8"
+    await sleepAsync(300.millis)
     mockServer.invalidateFilter(id)
-    echo "9"
-    await sleepAsync(200.millis)
-    echo "10"
+    await sleepAsync(300.millis)
     check mockServer.newFilterCounter == 2
-    echo "11"
 
   test "recreated filter can be still unsubscribed using the original id":
     let filter = EventFilter(address: Address.example, topics: @[array[32, byte].example])
@@ -165,7 +141,7 @@ suite "HTTP polling subscriptions - filter not found":
     let id = string.fromJson(jsonId).tryGet
     check mockServer.newFilterCounter == 1
 
-    await sleepAsync(200.millis)
+    await sleepAsync(300.millis)
     mockServer.invalidateFilter(id)
     check eventually mockServer.newFilterCounter == 2
     check mockServer.filters[id] == false

--- a/testmodule/providers/jsonrpc/testJsonRpcSubscriptions.nim
+++ b/testmodule/providers/jsonrpc/testJsonRpcSubscriptions.nim
@@ -147,11 +147,11 @@ suite "HTTP polling subscriptions - filter not found":
     check mockServer.newFilterCounter == 1
     echo "7"
 
-    await sleepAsync(50.millis)
+    await sleepAsync(200.millis)
     echo "8"
     mockServer.invalidateFilter(id)
     echo "9"
-    await sleepAsync(50.millis)
+    await sleepAsync(200.millis)
     echo "10"
     check mockServer.newFilterCounter == 2
     echo "11"
@@ -165,7 +165,7 @@ suite "HTTP polling subscriptions - filter not found":
     let id = string.fromJson(jsonId).tryGet
     check mockServer.newFilterCounter == 1
 
-    await sleepAsync(50.millis)
+    await sleepAsync(200.millis)
     mockServer.invalidateFilter(id)
     check eventually mockServer.newFilterCounter == 2
     check mockServer.filters[id] == false

--- a/testmodule/providers/jsonrpc/testJsonRpcSubscriptions.nim
+++ b/testmodule/providers/jsonrpc/testJsonRpcSubscriptions.nim
@@ -103,15 +103,24 @@ suite "HTTP polling subscriptions - filter not found":
   var mockServer: MockRpcHttpServer
 
   setup:
+    echo "Creating MockRpcHttpServer instance"
     mockServer = MockRpcHttpServer.new()
+    echo "Starting MockRpcHttpServer..."
     mockServer.start()
+    echo "Started MockRpcHttpServer"
 
+    echo "Creating new RpcHttpClient instance..."
     client = newRpcHttpClient()
+    echo "Connecting RpcHttpClient to MockRpcHttpServer..."
     await client.connect("http://" & $mockServer.localAddress()[0])
+    echo "Connected RpcHttpClient to MockRpcHttpServer"
 
+    echo "Creating new JsonRpcSubscriptions instance..."
     subscriptions = JsonRpcSubscriptions.new(client,
                                              pollingInterval = 15.millis)
+    echo "Starting JsonRpcSubscriptions..."
     subscriptions.start()
+    echo "Started JsonRpcSubscriptions"
 
   teardown:
     await subscriptions.close()

--- a/testmodule/providers/jsonrpc/testJsonRpcSubscriptions.nim
+++ b/testmodule/providers/jsonrpc/testJsonRpcSubscriptions.nim
@@ -117,7 +117,7 @@ suite "HTTP polling subscriptions - filter not found":
 
     echo "Creating new JsonRpcSubscriptions instance..."
     subscriptions = JsonRpcSubscriptions.new(client,
-                                             pollingInterval = 15.millis)
+                                             pollingInterval = 100.millis)
     echo "Starting JsonRpcSubscriptions..."
     subscriptions.start()
     echo "Started JsonRpcSubscriptions"

--- a/testmodule/providers/jsonrpc/testJsonRpcSubscriptions.nim
+++ b/testmodule/providers/jsonrpc/testJsonRpcSubscriptions.nim
@@ -123,9 +123,13 @@ suite "HTTP polling subscriptions - filter not found":
     echo "Started JsonRpcSubscriptions"
 
   teardown:
+    echo "Closing subscriptions..."
     await subscriptions.close()
+    echo "Closing client..."
     await client.close()
+    echo "Stopping mock server..."
     await mockServer.stop()
+    echo "Stopped mock server"
 
   test "filter not found error recreates filter":
     echo "1"


### PR DESCRIPTION
Ignore exceptions (other than CancelledError) if uninstallation of the filter fails. If it's the last step in the subscription cleanup, then filter changes for this filter will no longer be polled so if the filter continues to live on in geth for whatever reason, then it doesn't matter.