### PR TITLE
ci: add matrix status job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,31 +1,46 @@
 name: CI
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         nim: [1.6.20, stable]
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
+
     - name: Install Nim
-      uses: iffy/install-nim@v3
+      uses: iffy/install-nim@v4
       with:
         version: ${{ matrix.nim }}
+
     - name: Install NodeJS
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: 18
+
     - name: Install test node
       working-directory: testnode
       run: npm install
+
     - name: Run test node
       working-directory: testnode
       run: npm start &
+
     - name: Build
       run: nimble install -y
+
     - name: Test
       run: nimble test -y
+
+  status:
+    if: always()
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')  || contains(needs.*.result, 'skipped') }}
+        run: exit 1


### PR DESCRIPTION
PR make some CI adjustments
- add `status` job which can be used in the branch rules to not stick with the specific matrix job
- set matrix `timeout-minutes: 30` to fail fast, [default](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes) is 360 minutes
- added `workflow_dispatch` to be able to trigger workflow manually which is usefully for debugging
- actions updated to the latest major versions
- added spacing between the steps for better readability