### PR TITLE
fix: modify unsubscribe cleanup routine and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ nimble.develop
 nimble.paths
 .idea
 .nimble
+.envrc

--- a/Readme.md
+++ b/Readme.md
@@ -202,6 +202,9 @@ $ npm ci
 $ npm start
 ```
 
+If you need to use different port for the RPC node, then you can start with `npm start -- --port 1111` and
+then run the tests with `ETHERS_TEST_PROVIDER=1111 nimble test`.
+
 Thanks
 ------
 

--- a/ethers/providers/jsonrpc/subscriptions.nim
+++ b/ethers/providers/jsonrpc/subscriptions.nim
@@ -17,6 +17,7 @@ type
     methodHandlers: Table[string, MethodHandler]
   MethodHandler* = proc (j: JsonNode) {.gcsafe, raises: [].}
   SubscriptionCallback = proc(id, arguments: JsonNode) {.gcsafe, raises:[].}
+  SubscriptionError* = object of EthersError
 
 {.push raises:[].}
 
@@ -130,7 +131,7 @@ method unsubscribe*(subscriptions: WebSocketSubscriptions,
 # Polling
 
 type
-  PollingSubscriptions = ref object of JsonRpcSubscriptions
+  PollingSubscriptions* = ref object of JsonRpcSubscriptions
     polling: Future[void]
 
     # We need to keep around the filters that are used to create log filters on the RPC node
@@ -151,17 +152,24 @@ proc new*(_: type JsonRpcSubscriptions,
   proc getChanges(originalId: JsonNode): Future[JsonNode] {.async.} =
     try:
       let mappedId = subscriptions.subscriptionMapping[originalId]
-      echo "getting changes for originalId: ", $originalId, "; mappedId: ", $mappedId
-      return await subscriptions.client.eth_getFilterChanges(mappedId)
+      let changes = await subscriptions.client.eth_getFilterChanges(mappedId)
+      if changes.kind == JNull:
+        return newJArray()
+      elif changes.kind != JArray:
+        raise newException(SubscriptionError,
+          "HTTP polling: unexpected value returned from eth_getFilterChanges." &
+          " Expected: JArray, got: " & $changes.kind)
+      return changes
+    except CancelledError as e:
+      raise e
     except CatchableError as e:
       if "filter not found" in e.msg:
-        echo "filter not found - recreating; originalId: ", originalId
         let filter = subscriptions.filters[originalId]
         let newId = await subscriptions.client.eth_newFilter(filter)
-        echo "filter not found - newId: ", newId
         subscriptions.subscriptionMapping[originalId] = newId
-
-      return newJArray()
+        return await getChanges(originalId)
+      else:
+        raise e
 
   proc poll(id: JsonNode) {.async.} =
     for change in await getChanges(id):
@@ -171,9 +179,7 @@ proc new*(_: type JsonRpcSubscriptions,
   proc poll {.async.} =
     untilCancelled:
       for id in toSeq subscriptions.callbacks.keys:
-        echo "polling for key:", $id
         await poll(id)
-      echo "sleeping"
       await sleepAsync(pollingInterval)
 
   subscriptions.polling = poll()
@@ -226,13 +232,12 @@ method unsubscribe*(subscriptions: PollingSubscriptions,
   subscriptions.filters.del(id)
   subscriptions.callbacks.del(id)
   let sub = subscriptions.subscriptionMapping[id]
-  echo "unsubscribing; originalId: ", $id, "; mappedId: ", $sub
   subscriptions.subscriptionMapping.del(id)
   try:
     discard await subscriptions.client.eth_uninstallFilter(sub)
   except CancelledError as e:
     raise e
-  except CatchableError as e:
+  except CatchableError:
     # Ignore if uninstallation of the filter fails. If it's the last step in our
     # cleanup, then filter changes for this filter will no longer be polled so
     # if the filter continues to live on in geth for whatever reason then it

--- a/ethers/providers/jsonrpc/subscriptions.nim
+++ b/ethers/providers/jsonrpc/subscriptions.nim
@@ -175,11 +175,8 @@ proc new*(_: type JsonRpcSubscriptions,
   subscriptions
 
 method close*(subscriptions: PollingSubscriptions) {.async.} =
-  echo "Cancelling subscription polling..."
   await subscriptions.polling.cancelAndWait()
-  echo "Calling Provider.close..."
   await procCall JsonRpcSubscriptions(subscriptions).close()
-  echo "Close done."
 
 method subscribeBlocks(subscriptions: PollingSubscriptions,
                        onBlock: BlockHandler):

--- a/ethers/providers/jsonrpc/subscriptions.nim
+++ b/ethers/providers/jsonrpc/subscriptions.nim
@@ -175,8 +175,11 @@ proc new*(_: type JsonRpcSubscriptions,
   subscriptions
 
 method close*(subscriptions: PollingSubscriptions) {.async.} =
+  echo "Cancelling subscription polling..."
   await subscriptions.polling.cancelAndWait()
+  echo "Calling Provider.close..."
   await procCall JsonRpcSubscriptions(subscriptions).close()
+  echo "Close done."
 
 method subscribeBlocks(subscriptions: PollingSubscriptions,
                        onBlock: BlockHandler):

--- a/ethers/providers/jsonrpc/subscriptions.nim
+++ b/ethers/providers/jsonrpc/subscriptions.nim
@@ -220,9 +220,10 @@ method unsubscribe*(subscriptions: PollingSubscriptions,
                   {.async.} =
   subscriptions.filters.del(id)
   subscriptions.callbacks.del(id)
+  let sub = subscriptions.subscriptionMapping[id]
   subscriptions.subscriptionMapping.del(id)
   try:
-    discard await subscriptions.client.eth_uninstallFilter(subscriptions.subscriptionMapping[id])
+    discard await subscriptions.client.eth_uninstallFilter(sub)
   except CancelledError as e:
     raise e
   except CatchableError as e:

--- a/testmodule/providers/jsonrpc/rpc_mock.nim
+++ b/testmodule/providers/jsonrpc/rpc_mock.nim
@@ -6,7 +6,7 @@ import std/tables
 import pkg/stew/byteutils
 import pkg/json_rpc/rpcserver except `%`, `%*`
 import pkg/json_rpc/errors
-
+import std/random
 
 type MockRpcHttpServer* = ref object
   filters*: Table[string, bool]
@@ -14,7 +14,10 @@ type MockRpcHttpServer* = ref object
   srv: RpcHttpServer
 
 proc new*(_: type MockRpcHttpServer): MockRpcHttpServer =
-  MockRpcHttpServer(filters: initTable[string, bool](), newFilterCounter: 0, srv: newRpcHttpServer(["127.0.0.1:65080"]))
+  let port = rand(65000..<66000)
+  let srv = newRpcHttpServer(["127.0.0.1:" & port])
+  let filters = initTable[string, bool]()
+  MockRpcHttpServer(filters: filters, newFilterCounter: 0, srv: srv)
 
 proc invalidateFilter*(server: MockRpcHttpServer, id: string) =
   server.filters[id] = false

--- a/testmodule/providers/jsonrpc/rpc_mock.nim
+++ b/testmodule/providers/jsonrpc/rpc_mock.nim
@@ -14,10 +14,7 @@ type MockRpcHttpServer* = ref object
   srv: RpcHttpServer
 
 proc new*(_: type MockRpcHttpServer): MockRpcHttpServer =
-  let port = rand(49152..65535)
-  let srv = newRpcHttpServer(["127.0.0.1:" & $port])
-  let filters = initTable[string, bool]()
-  MockRpcHttpServer(filters: filters, newFilterCounter: 0, srv: srv)
+  MockRpcHttpServer(filters: initTable[string, bool](), newFilterCounter: 0, srv: newRpcHttpServer(["127.0.0.1:0"]))
 
 proc invalidateFilter*(server: MockRpcHttpServer, id: string) =
   server.filters[id] = false

--- a/testmodule/providers/jsonrpc/rpc_mock.nim
+++ b/testmodule/providers/jsonrpc/rpc_mock.nim
@@ -15,7 +15,7 @@ type MockRpcHttpServer* = ref object
 
 proc new*(_: type MockRpcHttpServer): MockRpcHttpServer =
   let port = rand(65000..<66000)
-  let srv = newRpcHttpServer(["127.0.0.1:" & port])
+  let srv = newRpcHttpServer(["127.0.0.1:" & $port])
   let filters = initTable[string, bool]()
   MockRpcHttpServer(filters: filters, newFilterCounter: 0, srv: srv)
 

--- a/testmodule/providers/jsonrpc/rpc_mock.nim
+++ b/testmodule/providers/jsonrpc/rpc_mock.nim
@@ -14,7 +14,7 @@ type MockRpcHttpServer* = ref object
   srv: RpcHttpServer
 
 proc new*(_: type MockRpcHttpServer): MockRpcHttpServer =
-  let port = rand(65000..<66000)
+  let port = rand(49152..65535)
   let srv = newRpcHttpServer(["127.0.0.1:" & $port])
   let filters = initTable[string, bool]()
   MockRpcHttpServer(filters: filters, newFilterCounter: 0, srv: srv)

--- a/testmodule/providers/jsonrpc/rpc_mock.nim
+++ b/testmodule/providers/jsonrpc/rpc_mock.nim
@@ -3,40 +3,39 @@ import ../../../ethers/provider
 import ../../../ethers/providers/jsonrpc/conversions
 
 import std/tables
+import std/sequtils
 import pkg/stew/byteutils
 import pkg/json_rpc/rpcserver except `%`, `%*`
 import pkg/json_rpc/errors
-import std/random
 
 type MockRpcHttpServer* = ref object
-  filters*: Table[string, bool]
-  newFilterCounter*: int
+  filters*: seq[string]
   srv: RpcHttpServer
 
 proc new*(_: type MockRpcHttpServer): MockRpcHttpServer =
-  MockRpcHttpServer(filters: initTable[string, bool](), newFilterCounter: 0, srv: newRpcHttpServer(["127.0.0.1:0"]))
+  let srv = newRpcHttpServer(["127.0.0.1:0"])
+  MockRpcHttpServer(filters: @[], srv: srv)
 
-proc invalidateFilter*(server: MockRpcHttpServer, id: string) =
-  server.filters[id] = false
+proc invalidateFilter*(server: MockRpcHttpServer, jsonId: JsonNode) =
+  server.filters.keepItIf it != jsonId.getStr
 
 proc start*(server: MockRpcHttpServer) =
   server.srv.router.rpc("eth_newFilter") do(filter: EventFilter) -> string:
     let filterId = "0x" & (array[16, byte].example).toHex
-    server.filters[filterId] = true
-    server.newFilterCounter += 1
+    server.filters.add filterId
     return filterId
 
   server.srv.router.rpc("eth_getFilterChanges") do(id: string) -> seq[string]:
-    if(not hasKey(server.filters, id) or not server.filters[id]):
+    if id notin server.filters:
       raise (ref ApplicationError)(code: -32000, msg: "filter not found")
 
     return @[]
 
   server.srv.router.rpc("eth_uninstallFilter") do(id: string) -> bool:
-    if(not hasKey(server.filters, id)):
+    if id notin server.filters:
       raise (ref ApplicationError)(code: -32000, msg: "filter not found")
 
-    server.filters.del(id)
+    server.invalidateFilter(%id)
     return true
 
   server.srv.start()
@@ -44,7 +43,6 @@ proc start*(server: MockRpcHttpServer) =
 proc stop*(server: MockRpcHttpServer) {.async.} =
   await server.srv.stop()
   await server.srv.closeWait()
-
 
 proc localAddress*(server: MockRpcHttpServer): seq[TransportAddress] =
   return server.srv.localAddress()

--- a/testmodule/providers/jsonrpc/rpc_mock.nim
+++ b/testmodule/providers/jsonrpc/rpc_mock.nim
@@ -14,7 +14,7 @@ type MockRpcHttpServer* = ref object
   srv: RpcHttpServer
 
 proc new*(_: type MockRpcHttpServer): MockRpcHttpServer =
-  MockRpcHttpServer(filters: initTable[string, bool](), newFilterCounter: 0, srv: newRpcHttpServer(["127.0.0.1:0"]))
+  MockRpcHttpServer(filters: initTable[string, bool](), newFilterCounter: 0, srv: newRpcHttpServer(["127.0.0.1:65080"]))
 
 proc invalidateFilter*(server: MockRpcHttpServer, id: string) =
   server.filters[id] = false

--- a/testmodule/providers/jsonrpc/testJsonRpcProvider.nim
+++ b/testmodule/providers/jsonrpc/testJsonRpcProvider.nim
@@ -1,3 +1,4 @@
+import std/os
 import pkg/asynctest
 import pkg/chronos
 import pkg/ethers
@@ -6,7 +7,7 @@ import pkg/stew/byteutils
 import ../../examples
 import ../../miner
 
-for url in ["ws://localhost:8545", "http://localhost:8545"]:
+for url in ["ws://" & getEnv("ETHERS_TEST_PROVIDER", "localhost:8545"), "http://"  & getEnv("ETHERS_TEST_PROVIDER", "localhost:8545")]:
 
   suite "JsonRpcProvider (" & url & ")":
 

--- a/testmodule/providers/jsonrpc/testJsonRpcProvider.nim
+++ b/testmodule/providers/jsonrpc/testJsonRpcProvider.nim
@@ -7,7 +7,8 @@ import pkg/stew/byteutils
 import ../../examples
 import ../../miner
 
-for url in ["ws://" & getEnv("ETHERS_TEST_PROVIDER", "localhost:8545"), "http://"  & getEnv("ETHERS_TEST_PROVIDER", "localhost:8545")]:
+let providerUrl = getEnv("ETHERS_TEST_PROVIDER", "localhost:8545")
+for url in ["ws://" & providerUrl, "http://"  & providerUrl]:
 
   suite "JsonRpcProvider (" & url & ")":
 

--- a/testmodule/providers/jsonrpc/testJsonRpcSigner.nim
+++ b/testmodule/providers/jsonrpc/testJsonRpcSigner.nim
@@ -8,9 +8,10 @@ suite "JsonRpcSigner":
 
   var provider: JsonRpcProvider
   var accounts: seq[Address]
+  let providerUrl = getEnv("ETHERS_TEST_PROVIDER", "localhost:8545")
 
   setup:
-    provider = JsonRpcProvider.new("http://" & getEnv("ETHERS_TEST_PROVIDER", "localhost:8545"))
+    provider = JsonRpcProvider.new("http://" & providerUrl)
     accounts = await provider.listAccounts()
 
   teardown:

--- a/testmodule/providers/jsonrpc/testJsonRpcSigner.nim
+++ b/testmodule/providers/jsonrpc/testJsonRpcSigner.nim
@@ -1,3 +1,4 @@
+import std/os
 import pkg/asynctest
 import pkg/ethers
 import pkg/stew/byteutils
@@ -9,7 +10,7 @@ suite "JsonRpcSigner":
   var accounts: seq[Address]
 
   setup:
-    provider = JsonRpcProvider.new()
+    provider = JsonRpcProvider.new("http://" & getEnv("ETHERS_TEST_PROVIDER", "localhost:8545"))
     accounts = await provider.listAccounts()
 
   teardown:

--- a/testmodule/providers/jsonrpc/testJsonRpcSubscriptions.nim
+++ b/testmodule/providers/jsonrpc/testJsonRpcSubscriptions.nim
@@ -128,18 +128,29 @@ suite "HTTP polling subscriptions - filter not found":
     await mockServer.stop()
 
   test "filter not found error recreates filter":
+    echo "1"
     let filter = EventFilter(address: Address.example, topics: @[array[32, byte].example])
+    echo "2"
     let emptyHandler = proc(log: Log) = discard
+    echo "3"
 
     check mockServer.newFilterCounter == 0
+    echo "4"
     let jsonId = await subscriptions.subscribeLogs(filter, emptyHandler)
+    echo "5"
     let id = string.fromJson(jsonId).tryGet
+    echo "6"
     check mockServer.newFilterCounter == 1
+    echo "7"
 
     await sleepAsync(50.millis)
+    echo "8"
     mockServer.invalidateFilter(id)
+    echo "9"
     await sleepAsync(50.millis)
+    echo "10"
     check mockServer.newFilterCounter == 2
+    echo "11"
 
   test "recreated filter can be still unsubscribed using the original id":
     let filter = EventFilter(address: Address.example, topics: @[array[32, byte].example])

--- a/testmodule/providers/jsonrpc/testJsonRpcSubscriptions.nim
+++ b/testmodule/providers/jsonrpc/testJsonRpcSubscriptions.nim
@@ -135,6 +135,8 @@ suite "HTTP polling subscriptions - filter not found":
 
     check subscriptions.filters[id] == filter
     check subscriptions.subscriptionMapping[id] == id
+    check subscriptions.filters.len == 1
+    check subscriptions.subscriptionMapping.len == 1
 
     mockServer.invalidateFilter(id)
 

--- a/testmodule/providers/jsonrpc/testJsonRpcSubscriptions.nim
+++ b/testmodule/providers/jsonrpc/testJsonRpcSubscriptions.nim
@@ -103,58 +103,34 @@ suite "HTTP polling subscriptions - filter not found":
   var mockServer: MockRpcHttpServer
 
   setup:
-    echo "Creating MockRpcHttpServer instance"
     mockServer = MockRpcHttpServer.new()
-    echo "Starting MockRpcHttpServer..."
     mockServer.start()
-    echo "Started MockRpcHttpServer"
 
-    echo "Creating new RpcHttpClient instance..."
     client = newRpcHttpClient()
-    echo "Connecting RpcHttpClient to MockRpcHttpServer..."
     await client.connect("http://" & $mockServer.localAddress()[0])
-    echo "Connected RpcHttpClient to MockRpcHttpServer"
 
-    echo "Creating new JsonRpcSubscriptions instance..."
     subscriptions = JsonRpcSubscriptions.new(client,
                                              pollingInterval = 100.millis)
-    echo "Starting JsonRpcSubscriptions..."
     subscriptions.start()
-    echo "Started JsonRpcSubscriptions"
 
   teardown:
-    echo "Closing subscriptions..."
     await subscriptions.close()
-    echo "Closing client..."
     await client.close()
-    echo "Stopping mock server..."
     await mockServer.stop()
-    echo "Stopped mock server"
 
   test "filter not found error recreates filter":
-    echo "1"
     let filter = EventFilter(address: Address.example, topics: @[array[32, byte].example])
-    echo "2"
     let emptyHandler = proc(log: Log) = discard
-    echo "3"
 
     check mockServer.newFilterCounter == 0
-    echo "4"
     let jsonId = await subscriptions.subscribeLogs(filter, emptyHandler)
-    echo "5"
     let id = string.fromJson(jsonId).tryGet
-    echo "6"
     check mockServer.newFilterCounter == 1
-    echo "7"
 
-    await sleepAsync(200.millis)
-    echo "8"
+    await sleepAsync(300.millis)
     mockServer.invalidateFilter(id)
-    echo "9"
-    await sleepAsync(200.millis)
-    echo "10"
+    await sleepAsync(300.millis)
     check mockServer.newFilterCounter == 2
-    echo "11"
 
   test "recreated filter can be still unsubscribed using the original id":
     let filter = EventFilter(address: Address.example, topics: @[array[32, byte].example])
@@ -165,7 +141,7 @@ suite "HTTP polling subscriptions - filter not found":
     let id = string.fromJson(jsonId).tryGet
     check mockServer.newFilterCounter == 1
 
-    await sleepAsync(200.millis)
+    await sleepAsync(300.millis)
     mockServer.invalidateFilter(id)
     check eventually mockServer.newFilterCounter == 2
     check mockServer.filters[id] == false

--- a/testmodule/providers/jsonrpc/testJsonRpcSubscriptions.nim
+++ b/testmodule/providers/jsonrpc/testJsonRpcSubscriptions.nim
@@ -147,11 +147,11 @@ suite "HTTP polling subscriptions - filter not found":
     check mockServer.newFilterCounter == 1
     echo "7"
 
-    await sleepAsync(50.millis)
+    await sleepAsync(200.millis)
     echo "8"
     mockServer.invalidateFilter(id)
     echo "9"
-    await sleepAsync(50.millis)
+    await sleepAsync(200.millis)
     echo "10"
     check mockServer.newFilterCounter == 2
     echo "11"
@@ -165,7 +165,7 @@ suite "HTTP polling subscriptions - filter not found":
     let id = string.fromJson(jsonId).tryGet
     check mockServer.newFilterCounter == 1
 
-    await sleepAsync(50.millis)
+    await sleepAsync(200.millis)
     mockServer.invalidateFilter(id)
     check eventually mockServer.newFilterCounter == 2
     check mockServer.filters[id] == false

--- a/testmodule/providers/jsonrpc/testJsonRpcSubscriptions.nim
+++ b/testmodule/providers/jsonrpc/testJsonRpcSubscriptions.nim
@@ -103,15 +103,24 @@ suite "HTTP polling subscriptions - filter not found":
   var mockServer: MockRpcHttpServer
 
   setup:
+    echo "Creating MockRpcHttpServer instance"
     mockServer = MockRpcHttpServer.new()
+    echo "Starting MockRpcHttpServer..."
     mockServer.start()
+    echo "Started MockRpcHttpServer"
 
+    echo "Creating new RpcHttpClient instance..."
     client = newRpcHttpClient()
+    echo "Connecting RpcHttpClient to MockRpcHttpServer..."
     await client.connect("http://" & $mockServer.localAddress()[0])
+    echo "Connected RpcHttpClient to MockRpcHttpServer"
 
+    echo "Creating new JsonRpcSubscriptions instance..."
     subscriptions = JsonRpcSubscriptions.new(client,
                                              pollingInterval = 15.millis)
+    echo "Starting JsonRpcSubscriptions..."
     subscriptions.start()
+    echo "Started JsonRpcSubscriptions"
 
   teardown:
     await subscriptions.close()

--- a/testmodule/providers/jsonrpc/testJsonRpcSubscriptions.nim
+++ b/testmodule/providers/jsonrpc/testJsonRpcSubscriptions.nim
@@ -117,7 +117,7 @@ suite "HTTP polling subscriptions - filter not found":
 
     echo "Creating new JsonRpcSubscriptions instance..."
     subscriptions = JsonRpcSubscriptions.new(client,
-                                             pollingInterval = 15.millis)
+                                             pollingInterval = 100.millis)
     echo "Starting JsonRpcSubscriptions..."
     subscriptions.start()
     echo "Started JsonRpcSubscriptions"

--- a/testmodule/providers/jsonrpc/testJsonRpcSubscriptions.nim
+++ b/testmodule/providers/jsonrpc/testJsonRpcSubscriptions.nim
@@ -1,6 +1,7 @@
 import std/json
 import std/os
 import std/sequtils
+import std/importutils
 import pkg/asynctest
 import pkg/serde
 import pkg/json_rpc/rpcclient
@@ -99,9 +100,11 @@ suite "HTTP polling subscriptions":
 
 suite "HTTP polling subscriptions - filter not found":
 
-  var subscriptions: JsonRpcSubscriptions
+  var subscriptions: PollingSubscriptions
   var client: RpcHttpClient
   var mockServer: MockRpcHttpServer
+
+  privateAccess(PollingSubscriptions)
 
   setup:
     mockServer = MockRpcHttpServer.new()
@@ -110,8 +113,10 @@ suite "HTTP polling subscriptions - filter not found":
     client = newRpcHttpClient()
     await client.connect("http://" & $mockServer.localAddress()[0])
 
-    subscriptions = JsonRpcSubscriptions.new(client,
-                                             pollingInterval = 100.millis)
+    subscriptions = PollingSubscriptions(
+                      JsonRpcSubscriptions.new(
+                        client,
+                        pollingInterval = 1.millis))
     subscriptions.start()
 
   teardown:
@@ -123,35 +128,26 @@ suite "HTTP polling subscriptions - filter not found":
     let filter = EventFilter(address: Address.example, topics: @[array[32, byte].example])
     let emptyHandler = proc(log: Log) = discard
 
-    check mockServer.newFilterCounter == 0
-    let jsonId = await subscriptions.subscribeLogs(filter, emptyHandler)
-    let id = string.fromJson(jsonId).tryGet
-    check mockServer.newFilterCounter == 1
+    check subscriptions.filters.len == 0
+    check subscriptions.subscriptionMapping.len == 0
 
-    await sleepAsync(300.millis)
+    let id = await subscriptions.subscribeLogs(filter, emptyHandler)
+
+    check subscriptions.filters[id] == filter
+    check subscriptions.subscriptionMapping[id] == id
+
     mockServer.invalidateFilter(id)
-    await sleepAsync(300.millis)
-    check mockServer.newFilterCounter == 2
+
+    check eventually subscriptions.subscriptionMapping[id] != id
 
   test "recreated filter can be still unsubscribed using the original id":
     let filter = EventFilter(address: Address.example, topics: @[array[32, byte].example])
     let emptyHandler = proc(log: Log) = discard
-
-    check mockServer.newFilterCounter == 0
-    let jsonId = await subscriptions.subscribeLogs(filter, emptyHandler)
-    let id = string.fromJson(jsonId).tryGet
-    check mockServer.newFilterCounter == 1
-
-    await sleepAsync(300.millis)
+    let id = await subscriptions.subscribeLogs(filter, emptyHandler)
     mockServer.invalidateFilter(id)
-    check eventually mockServer.newFilterCounter == 2
-    check mockServer.filters[id] == false
-    check mockServer.filters.len() == 2
-    await subscriptions.unsubscribe(jsonId)
-    check mockServer.filters.len() == 1
+    check eventually subscriptions.subscriptionMapping[id] != id
 
-    # invalidateFilter sets the filter's value to false which will return the "filter not found"
-    # unsubscribing will actually delete the key from filters table
-    # hence after unsubscribing the only key left in the table should be the original id
-    for key in mockServer.filters.keys():
-      check key == id
+    await subscriptions.unsubscribe(id)
+
+    check not subscriptions.filters.hasKey id
+    check not subscriptions.subscriptionMapping.hasKey id

--- a/testmodule/providers/jsonrpc/testJsonRpcSubscriptions.nim
+++ b/testmodule/providers/jsonrpc/testJsonRpcSubscriptions.nim
@@ -123,9 +123,13 @@ suite "HTTP polling subscriptions - filter not found":
     echo "Started JsonRpcSubscriptions"
 
   teardown:
+    echo "Closing subscriptions..."
     await subscriptions.close()
+    echo "Closing client..."
     await client.close()
+    echo "Stopping mock server..."
     await mockServer.stop()
+    echo "Stopped mock server"
 
   test "filter not found error recreates filter":
     echo "1"

--- a/testmodule/providers/jsonrpc/testJsonRpcSubscriptions.nim
+++ b/testmodule/providers/jsonrpc/testJsonRpcSubscriptions.nim
@@ -1,4 +1,5 @@
 import std/json
+import std/os
 import std/sequtils
 import pkg/asynctest
 import pkg/serde
@@ -68,7 +69,7 @@ suite "Web socket subscriptions":
 
   setup:
     client = newRpcWebSocketClient()
-    await client.connect("ws://localhost:8545")
+    await client.connect("ws://"  & getEnv("ETHERS_TEST_PROVIDER", "localhost:8545"))
     subscriptions = JsonRpcSubscriptions.new(client)
     subscriptions.start()
 
@@ -85,7 +86,7 @@ suite "HTTP polling subscriptions":
 
   setup:
     client = newRpcHttpClient()
-    await client.connect("http://localhost:8545")
+    await client.connect("http://" & getEnv("ETHERS_TEST_PROVIDER", "localhost:8545"))
     subscriptions = JsonRpcSubscriptions.new(client,
                                              pollingInterval = 100.millis)
     subscriptions.start()

--- a/testmodule/testContracts.nim
+++ b/testmodule/testContracts.nim
@@ -17,7 +17,8 @@ type
 method mint(token: TestToken, holder: Address, amount: UInt256): Confirmable {.base, contract.}
 method myBalance(token: TestToken): UInt256 {.base, contract, view.}
 
-for url in ["ws://"  & getEnv("ETHERS_TEST_PROVIDER", "localhost:8545"), "http://"  & getEnv("ETHERS_TEST_PROVIDER", "localhost:8545")]:
+let providerUrl = getEnv("ETHERS_TEST_PROVIDER", "localhost:8545")
+for url in ["ws://"  & providerUrl, "http://"  & providerUrl]:
 
   suite "Contracts (" & url & ")":
 

--- a/testmodule/testContracts.nim
+++ b/testmodule/testContracts.nim
@@ -1,4 +1,5 @@
 import std/json
+import std/os
 import std/options
 import pkg/asynctest
 import pkg/questionable
@@ -16,7 +17,7 @@ type
 method mint(token: TestToken, holder: Address, amount: UInt256): Confirmable {.base, contract.}
 method myBalance(token: TestToken): UInt256 {.base, contract, view.}
 
-for url in ["ws://localhost:8545", "http://localhost:8545"]:
+for url in ["ws://"  & getEnv("ETHERS_TEST_PROVIDER", "localhost:8545"), "http://"  & getEnv("ETHERS_TEST_PROVIDER", "localhost:8545")]:
 
   suite "Contracts (" & url & ")":
 

--- a/testmodule/testCustomErrors.nim
+++ b/testmodule/testCustomErrors.nim
@@ -23,9 +23,10 @@ suite "Contract custom errors":
   var contract: TestCustomErrors
   var provider: JsonRpcProvider
   var snapshot: JsonNode
+  let providerUrl = getEnv("ETHERS_TEST_PROVIDER", "localhost:8545")
 
   setup:
-    provider = JsonRpcProvider.new("http://" & getEnv("ETHERS_TEST_PROVIDER", "localhost:8545"))
+    provider = JsonRpcProvider.new("http://" & providerUrl)
     snapshot = await provider.send("evm_snapshot")
     let deployment = readDeployment()
     let address = !deployment.address(TestCustomErrors)

--- a/testmodule/testCustomErrors.nim
+++ b/testmodule/testCustomErrors.nim
@@ -1,3 +1,4 @@
+import std/os
 import std/json
 import pkg/asynctest
 import pkg/ethers
@@ -24,7 +25,7 @@ suite "Contract custom errors":
   var snapshot: JsonNode
 
   setup:
-    provider = JsonRpcProvider.new()
+    provider = JsonRpcProvider.new("http://" & getEnv("ETHERS_TEST_PROVIDER", "localhost:8545"))
     snapshot = await provider.send("evm_snapshot")
     let deployment = readDeployment()
     let address = !deployment.address(TestCustomErrors)

--- a/testmodule/testEnums.nim
+++ b/testmodule/testEnums.nim
@@ -1,3 +1,4 @@
+import std/os
 import pkg/asynctest
 import pkg/ethers
 import pkg/serde
@@ -16,7 +17,7 @@ suite "Contract enum parameters and return values":
   var snapshot: JsonNode
 
   setup:
-    provider = JsonRpcProvider.new()
+    provider = JsonRpcProvider.new("http://" & getEnv("ETHERS_TEST_PROVIDER", "localhost:8545"))
     snapshot = await provider.send("evm_snapshot")
     let deployment = readDeployment()
     contract = TestEnums.new(!deployment.address(TestEnums), provider)

--- a/testmodule/testEnums.nim
+++ b/testmodule/testEnums.nim
@@ -15,9 +15,10 @@ suite "Contract enum parameters and return values":
   var contract: TestEnums
   var provider: JsonRpcProvider
   var snapshot: JsonNode
+  let providerUrl = getEnv("ETHERS_TEST_PROVIDER", "localhost:8545")
 
   setup:
-    provider = JsonRpcProvider.new("http://" & getEnv("ETHERS_TEST_PROVIDER", "localhost:8545"))
+    provider = JsonRpcProvider.new("http://" & providerUrl)
     snapshot = await provider.send("evm_snapshot")
     let deployment = readDeployment()
     contract = TestEnums.new(!deployment.address(TestEnums), provider)

--- a/testmodule/testErc20.nim
+++ b/testmodule/testErc20.nim
@@ -12,7 +12,8 @@ type
 
 method mint(token: TestToken, holder: Address, amount: UInt256): Confirmable {.base, contract.}
 
-for url in ["ws://" & getEnv("ETHERS_TEST_PROVIDER", "localhost:8545"), "http://"  & getEnv("ETHERS_TEST_PROVIDER", "localhost:8545")]:
+let providerUrl = getEnv("ETHERS_TEST_PROVIDER", "localhost:8545")
+for url in ["ws://" & providerUrl, "http://"  & providerUrl]:
 
   suite "ERC20 (" & url & ")":
 

--- a/testmodule/testErc20.nim
+++ b/testmodule/testErc20.nim
@@ -1,3 +1,4 @@
+import std/os
 import std/json
 import pkg/asynctest
 import pkg/questionable
@@ -11,7 +12,7 @@ type
 
 method mint(token: TestToken, holder: Address, amount: UInt256): Confirmable {.base, contract.}
 
-for url in ["ws://localhost:8545", "http://localhost:8545"]:
+for url in ["ws://" & getEnv("ETHERS_TEST_PROVIDER", "localhost:8545"), "http://"  & getEnv("ETHERS_TEST_PROVIDER", "localhost:8545")]:
 
   suite "ERC20 (" & url & ")":
 

--- a/testmodule/testGasEstimation.nim
+++ b/testmodule/testGasEstimation.nim
@@ -1,3 +1,4 @@
+import std/os
 import pkg/asynctest
 import pkg/ethers
 import pkg/serde
@@ -16,7 +17,7 @@ suite "gas estimation":
   var snapshot: JsonNode
 
   setup:
-    provider = JsonRpcProvider.new()
+    provider = JsonRpcProvider.new("http://" & getEnv("ETHERS_TEST_PROVIDER", "localhost:8545"))
     snapshot = await provider.send("evm_snapshot")
     let deployment = readDeployment()
     let signer = provider.getSigner()

--- a/testmodule/testGasEstimation.nim
+++ b/testmodule/testGasEstimation.nim
@@ -15,9 +15,10 @@ suite "gas estimation":
   var contract: TestGasEstimation
   var provider: JsonRpcProvider
   var snapshot: JsonNode
+  let providerUrl = getEnv("ETHERS_TEST_PROVIDER", "localhost:8545")
 
   setup:
-    provider = JsonRpcProvider.new("http://" & getEnv("ETHERS_TEST_PROVIDER", "localhost:8545"))
+    provider = JsonRpcProvider.new("http://" & providerUrl)
     snapshot = await provider.send("evm_snapshot")
     let deployment = readDeployment()
     let signer = provider.getSigner()

--- a/testmodule/testReturns.nim
+++ b/testmodule/testReturns.nim
@@ -14,9 +14,10 @@ suite "Contract return values":
   var contract: TestReturns
   var provider: JsonRpcProvider
   var snapshot: JsonNode
+  let providerUrl = getEnv("ETHERS_TEST_PROVIDER", "localhost:8545")
 
   setup:
-    provider = JsonRpcProvider.new("http://" & getEnv("ETHERS_TEST_PROVIDER", "localhost:8545"))
+    provider = JsonRpcProvider.new("http://" & providerUrl)
     snapshot = await provider.send("evm_snapshot")
     let deployment = readDeployment()
     contract = TestReturns.new(!deployment.address(TestReturns), provider)

--- a/testmodule/testReturns.nim
+++ b/testmodule/testReturns.nim
@@ -1,3 +1,4 @@
+import std/os
 import pkg/asynctest
 import pkg/ethers
 import pkg/serde
@@ -15,7 +16,7 @@ suite "Contract return values":
   var snapshot: JsonNode
 
   setup:
-    provider = JsonRpcProvider.new()
+    provider = JsonRpcProvider.new("http://" & getEnv("ETHERS_TEST_PROVIDER", "localhost:8545"))
     snapshot = await provider.send("evm_snapshot")
     let deployment = readDeployment()
     contract = TestReturns.new(!deployment.address(TestReturns), provider)

--- a/testmodule/testTesting.nim
+++ b/testmodule/testTesting.nim
@@ -1,3 +1,4 @@
+import std/os
 import std/strformat
 import pkg/asynctest
 import pkg/chronos
@@ -94,7 +95,7 @@ suite "Testing helpers - contracts":
   let revertReason = "revert reason"
 
   setup:
-    provider = JsonRpcProvider.new("ws://127.0.0.1:8545")
+    provider = JsonRpcProvider.new("ws://" & getEnv("ETHERS_TEST_PROVIDER", "localhost:8545"))
     snapshot = await provider.send("evm_snapshot")
     accounts = await provider.listAccounts()
     helpersContract = TestHelpers.new(provider.getSigner())

--- a/testmodule/testTesting.nim
+++ b/testmodule/testTesting.nim
@@ -93,9 +93,10 @@ suite "Testing helpers - contracts":
   var snapshot: JsonNode
   var accounts: seq[Address]
   let revertReason = "revert reason"
+  let providerUrl = getEnv("ETHERS_TEST_PROVIDER", "localhost:8545")
 
   setup:
-    provider = JsonRpcProvider.new("ws://" & getEnv("ETHERS_TEST_PROVIDER", "localhost:8545"))
+    provider = JsonRpcProvider.new("ws://" & providerUrl)
     snapshot = await provider.send("evm_snapshot")
     accounts = await provider.listAccounts()
     helpersContract = TestHelpers.new(provider.getSigner())

--- a/testmodule/testWallet.nim
+++ b/testmodule/testWallet.nim
@@ -13,9 +13,10 @@ proc transfer*(erc20: Erc20, recipient: Address, amount: UInt256) {.contract.}
 suite "Wallet":
   var provider: JsonRpcProvider
   var snapshot: JsonNode
+  let providerUrl = getEnv("ETHERS_TEST_PROVIDER", "localhost:8545")
 
   setup:
-    provider = JsonRpcProvider.new("http://" & getEnv("ETHERS_TEST_PROVIDER", "localhost:8545"))
+    provider = JsonRpcProvider.new("http://" & providerUrl)
     snapshot = await provider.send("evm_snapshot")
 
   teardown:

--- a/testmodule/testWallet.nim
+++ b/testmodule/testWallet.nim
@@ -1,3 +1,4 @@
+import std/os
 import pkg/asynctest
 import pkg/serde
 import pkg/stew/byteutils
@@ -14,7 +15,7 @@ suite "Wallet":
   var snapshot: JsonNode
 
   setup:
-    provider = JsonRpcProvider.new()
+    provider = JsonRpcProvider.new("http://" & getEnv("ETHERS_TEST_PROVIDER", "localhost:8545"))
     snapshot = await provider.send("evm_snapshot")
 
   teardown:


### PR DESCRIPTION
Closes #79 

Modifying the cleanup:
- Ignore exceptions (other than CancelledError) if uninstallation of the filter fails. If it's the last step in the subscription cleanup, then filter changes for this filter will no longer be polled so if the filter continues to live on in geth for whatever reason, then it doesn't matter.

To fix the subscription filter tests:
- `CancelledError` is now caught inside of `getChanges`. This was causing conditions during `subscriptions.close`, where the `CancelledError` would get consumed by the `except CatchableError`, if there was an ongoing `poll` happening at the time of close.
- After creating a new filter inside of `getChanges`, the new filter is polled for changes before returning.
- `getChanges` also does not swallow `CatchableError` by returning an empty array, and instead re-raises the error if it is not `filter not found`.
- #79 was fixed by checking the return value of `eth_getFilterChanges`. If `JNull` was received, then an empty array is returned.
- The tests were simplified by accessing the private fields of `PollingSubscriptions`. That way, there wasn't a race condition for the `newFilterId` counter inside of the mock.
- The `MockRpcHttpServer` was simplified by keeping track of the active filters only, and invalidation simply removes the filter. The tests then only needed to rely on the fact that the filter id changed in the mapping.
- Because of the above changes, we no longer needed to sleep inside of the tests, so the sleeps were removed, and the polling interval could be changed to 1ms, which not only makes the tests faster, but would further highlight any race conditions if present.

Co-authored-by: Adam Uhlíř <adam@uhlir.dev>