### PR TITLE
fix: `items(JsonNode)` symbol not found

### DIFF
--- a/ethers/contract.nim
+++ b/ethers/contract.nim
@@ -1,4 +1,4 @@
-import std/json
+import pkg/serde
 import std/macros
 import std/sequtils
 import pkg/chronicles

--- a/ethers/nimshims/hashes.nim
+++ b/ethers/nimshims/hashes.nim
@@ -2,7 +2,7 @@
 ## `std/json.JsonNode.hash`, eg when using `JsonNode` as a `Table` key. Adds
 ## {.raises: [].} for proper exception tracking. Copied from the std/json module
 
-import std/json
+import pkg/serde
 import std/hashes
 
 {.push raises:[].}

--- a/ethers/providers/jsonrpc.nim
+++ b/ethers/providers/jsonrpc.nim
@@ -17,6 +17,7 @@ export basics
 export provider
 export chronicles
 export errors.JsonRpcProviderError
+export subscriptions
 
 {.push raises: [].}
 

--- a/ethers/providers/jsonrpc/subscriptions.nim
+++ b/ethers/providers/jsonrpc/subscriptions.nim
@@ -3,12 +3,15 @@ import std/sequtils
 import std/strutils
 import pkg/chronos
 import pkg/json_rpc/rpcclient
+import pkg/serde
 import ../../basics
 import ../../provider
 include ../../nimshims/hashes
 import ./rpccalls
 import ./conversions
 import ./looping
+
+export serde
 
 type
   JsonRpcSubscriptions* = ref object of RootObj

--- a/testmodule/hardhat.nim
+++ b/testmodule/hardhat.nim
@@ -1,4 +1,4 @@
-import std/json
+import pkg/serde
 import pkg/ethers/basics
 
 type Deployment* = object

--- a/testmodule/providers/jsonrpc/testErrors.nim
+++ b/testmodule/providers/jsonrpc/testErrors.nim
@@ -1,5 +1,5 @@
 import std/unittest
-import std/json
+import pkg/serde
 import pkg/questionable
 import pkg/ethers/providers/jsonrpc/errors
 

--- a/testmodule/providers/jsonrpc/testJsonRpcSubscriptions.nim
+++ b/testmodule/providers/jsonrpc/testJsonRpcSubscriptions.nim
@@ -1,4 +1,4 @@
-import std/json
+import pkg/serde
 import std/os
 import std/sequtils
 import std/importutils

--- a/testmodule/testContracts.nim
+++ b/testmodule/testContracts.nim
@@ -1,4 +1,4 @@
-import std/json
+import pkg/serde
 import std/os
 import std/options
 import pkg/asynctest

--- a/testmodule/testCustomErrors.nim
+++ b/testmodule/testCustomErrors.nim
@@ -1,5 +1,5 @@
 import std/os
-import std/json
+import pkg/serde
 import pkg/asynctest
 import pkg/ethers
 import ./hardhat

--- a/testmodule/testErc20.nim
+++ b/testmodule/testErc20.nim
@@ -1,5 +1,5 @@
 import std/os
-import std/json
+import pkg/serde
 import pkg/asynctest
 import pkg/questionable
 import pkg/stint


### PR DESCRIPTION
- Fixes `items(JsonNode)` symbol not found when calling `JsonRpcProvider.new` from a consumer. Exporting `serde` from `subscriptions` and then exporting `subscriptions` from `jsonrpc` allowed the symbols to be resolved in the consumer.

- Replaces all instances of `std/json` with `pkg/serde`