### PR TITLE
fix: block filters can be also recreated

### DIFF
--- a/ethers/errors.nim
+++ b/ethers/errors.nim
@@ -1,6 +1,16 @@
 import ./basics
 
-type SolidityError* = object of EthersError
+type
+  SolidityError* = object of EthersError
+  ContractError* = object of EthersError
+  SignerError* = object of EthersError
+  SubscriptionError* = object of EthersError
+  SubscriptionResult*[E] = Result[E, ref SubscriptionError]
+  ProviderError* = object of EthersError
+    data*: ?seq[byte]
+
+template raiseSignerError*(message: string, parent: ref ProviderError = nil) =
+  raise newException(SignerError, message, parent)
 
 {.push raises:[].}
 

--- a/ethers/providers/jsonrpc/subscriptions.nim
+++ b/ethers/providers/jsonrpc/subscriptions.nim
@@ -164,8 +164,14 @@ proc new*(_: type JsonRpcSubscriptions,
       raise e
     except CatchableError as e:
       if "filter not found" in e.msg:
-        let filter = subscriptions.filters[originalId]
-        let newId = await subscriptions.client.eth_newFilter(filter)
+        var newId: JsonNode
+        # If there exists filter for given ID, then the filter was a log filter
+        # otherwise it was a block filter
+        if subscriptions.filters.hasKey(originalId):
+          let filter = subscriptions.filters[originalId]
+          newId = await subscriptions.client.eth_newFilter(filter)
+        else:
+          newId = await subscriptions.client.eth_newBlockFilter()
         subscriptions.subscriptionMapping[originalId] = newId
         return await getChanges(originalId)
       else:

--- a/ethers/signer.nim
+++ b/ethers/signer.nim
@@ -1,5 +1,6 @@
 import pkg/questionable
 import ./basics
+import ./errors
 import ./provider
 
 export basics
@@ -9,10 +10,6 @@ export basics
 type
   Signer* = ref object of RootObj
     populateLock: AsyncLock
-  SignerError* = object of EthersError
-
-template raiseSignerError(message: string, parent: ref ProviderError = nil) =
-  raise newException(SignerError, message, parent)
 
 template convertError(body) =
   try:

--- a/testmodule/providers/jsonrpc/rpc_mock.nim
+++ b/testmodule/providers/jsonrpc/rpc_mock.nim
@@ -25,6 +25,11 @@ proc start*(server: MockRpcHttpServer) =
     server.filters.add filterId
     return filterId
 
+  server.srv.router.rpc("eth_newBlockFilter") do() -> string:
+    let filterId = "0x" & (array[16, byte].example).toHex
+    server.filters.add filterId
+    return filterId
+
   server.srv.router.rpc("eth_getFilterChanges") do(id: string) -> seq[string]:
     if id notin server.filters:
       raise (ref ApplicationError)(code: -32000, msg: "filter not found")


### PR DESCRIPTION
Adds Result to the Subscription's handlers that will return errors when any error in the underlaying subscription mechanism (for example HTTP polling) surface.