### PR TITLE
feat: subscriptions handlers get results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: CI
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   test:

--- a/Readme.md
+++ b/Readme.md
@@ -131,14 +131,20 @@ You can now subscribe to Transfer events by calling `subscribe` on the contract
 instance.
 
 ```nim
-proc handleTransfer(transfer: Transfer) =
-  echo "received transfer: ", transfer
+proc handleTransfer(transferResult: ?!Transfer) =
+  if transferResult.isOk:
+    echo "received transfer: ", transferResult.value
 
 let subscription = await token.subscribe(Transfer, handleTransfer)
 ```
 
 When a Transfer event is emitted, the `handleTransfer` proc that you just
-defined will be called.
+defined will be called with a [Result](https://github.com/arnetheduck/nim-results) type
+which contains the event value.
+
+In case there is some underlying error in the event subscription, the handler will
+be called as well, but the Result will contain error instead, so do proper error
+management in your handlers.
 
 When you're no longer interested in these events, you can unsubscribe:
 

--- a/ethers/contract.nim
+++ b/ethers/contract.nim
@@ -293,8 +293,8 @@ proc subscribe*[E: Event](contract: Contract,
   let filter = EventFilter(address: contract.address, topics: @[topic])
 
   proc logHandler(logResult: ?!Log) {.raises: [].} =
-    without log =? logResult, err:
-      handler(failure(E, err))
+    without log =? logResult, error:
+      handler(failure(E, error))
       return
 
     if event =? E.decode(log.data, log.topics):

--- a/ethers/contract.nim
+++ b/ethers/contract.nim
@@ -3,6 +3,7 @@ import std/macros
 import std/sequtils
 import pkg/chronicles
 import pkg/chronos
+import pkg/questionable
 import pkg/contractabi
 import ./basics
 import ./provider
@@ -35,11 +36,10 @@ type
     gasLimit*: ?UInt256
   CallOverrides* = ref object of TransactionOverrides
     blockTag*: ?BlockTag
-  ContractError* = object of EthersError
   Confirmable* = object
     response*: ?TransactionResponse
     convert*: ConvertCustomErrors
-  EventHandler*[E: Event] = proc(event: E) {.gcsafe, raises:[].}
+  EventHandler*[E: Event] = proc(event: ?!E) {.gcsafe, raises:[].}
 
 func new*(ContractType: type Contract,
           address: Address,
@@ -292,9 +292,13 @@ proc subscribe*[E: Event](contract: Contract,
   let topic = topic($E, E.fieldTypes).toArray
   let filter = EventFilter(address: contract.address, topics: @[topic])
 
-  proc logHandler(log: Log) {.raises: [].} =
+  proc logHandler(logResult: ?!Log) {.raises: [].} =
+    without log =? logResult, err:
+      handler(failure(E, err))
+      return
+
     if event =? E.decode(log.data, log.topics):
-      handler(event)
+      handler(success(event))
 
   contract.provider.subscribe(filter, logHandler)
 

--- a/ethers/errors.nim
+++ b/ethers/errors.nim
@@ -1,7 +1,23 @@
 import ./basics
 
-type SolidityError* = object of EthersError
+type
+  SolidityError* = object of EthersError
+  ContractError* = object of EthersError
+  SignerError* = object of EthersError
+  SubscriptionError* = object of EthersError
+  ProviderError* = object of EthersError
+    data*: ?seq[byte]
+
+template raiseSignerError*(message: string, parent: ref ProviderError = nil) =
+  raise newException(SignerError, message, parent)
 
 {.push raises:[].}
+
+proc toErr*[E1: ref CatchableError, E2: EthersError](
+  e1: E1,
+  _: type E2,
+  msg: string = e1.msg): ref E2 =
+
+  return newException(E2, msg, e1)
 
 template errors*(types) {.pragma.}

--- a/ethers/providers/jsonrpc/errors.nim
+++ b/ethers/providers/jsonrpc/errors.nim
@@ -1,8 +1,11 @@
 import std/strutils
 import pkg/stew/byteutils
 import ../../basics
+import ../../errors
 import ../../provider
 import ./conversions
+
+export errors
 
 {.push raises:[].}
 

--- a/ethers/signer.nim
+++ b/ethers/signer.nim
@@ -1,18 +1,16 @@
 import pkg/questionable
 import ./basics
+import ./errors
 import ./provider
 
 export basics
+export errors
 
 {.push raises: [].}
 
 type
   Signer* = ref object of RootObj
     populateLock: AsyncLock
-  SignerError* = object of EthersError
-
-template raiseSignerError(message: string, parent: ref ProviderError = nil) =
-  raise newException(SignerError, message, parent)
 
 template convertError(body) =
   try:

--- a/testmodule/providers/jsonrpc/rpc_mock.nim
+++ b/testmodule/providers/jsonrpc/rpc_mock.nim
@@ -2,7 +2,6 @@ import ../../examples
 import ../../../ethers/provider
 import ../../../ethers/providers/jsonrpc/conversions
 
-import std/tables
 import std/sequtils
 import pkg/stew/byteutils
 import pkg/json_rpc/rpcserver except `%`, `%*`

--- a/testmodule/providers/jsonrpc/testJsonRpcProvider.nim
+++ b/testmodule/providers/jsonrpc/testJsonRpcProvider.nim
@@ -49,7 +49,7 @@ for url in ["ws://" & providerUrl, "http://"  & providerUrl]:
       let oldBlock = !await provider.getBlock(BlockTag.latest)
       discard await provider.send("evm_mine")
       var newBlock: Block
-      let blockHandler = proc(blck: Block) = newBlock = blck
+      let blockHandler = proc(blck: ?!Block) {.raises:[].}= newBlock = blck.value
       let subscription = await provider.subscribe(blockHandler)
       discard await provider.send("evm_mine")
       check eventually newBlock.number.isSome
@@ -98,7 +98,7 @@ for url in ["ws://" & providerUrl, "http://"  & providerUrl]:
       expect JsonRpcProviderError:
         discard await provider.getBlock(BlockTag.latest)
       expect JsonRpcProviderError:
-        discard await provider.subscribe(proc(_: Block) = discard)
+        discard await provider.subscribe(proc(_: ?!Block) = discard)
       expect JsonRpcProviderError:
         discard await provider.getSigner().sendTransaction(Transaction.example)
 

--- a/testmodule/testContracts.nim
+++ b/testmodule/testContracts.nim
@@ -149,8 +149,9 @@ for url in ["ws://"  & providerUrl, "http://"  & providerUrl]:
     test "receives events when subscribed":
       var transfers: seq[Transfer]
 
-      proc handleTransfer(transfer: Transfer) =
-        transfers.add(transfer)
+      proc handleTransfer(transferRes: ?!Transfer) =
+        if transfer =? transferRes:
+          transfers.add(transfer)
 
       let signer0 = provider.getSigner(accounts[0])
       let signer1 = provider.getSigner(accounts[1])
@@ -171,8 +172,9 @@ for url in ["ws://"  & providerUrl, "http://"  & providerUrl]:
     test "stops receiving events when unsubscribed":
       var transfers: seq[Transfer]
 
-      proc handleTransfer(transfer: Transfer) =
-        transfers.add(transfer)
+      proc handleTransfer(transferRes: ?!Transfer) =
+        if transfer =? transferRes:
+          transfers.add(transfer)
 
       let signer0 = provider.getSigner(accounts[0])
 


### PR DESCRIPTION
Introduces breaking change to API, where subscription handlers now return `Result` type. Handlers, similarly to now will be called with events wrapped in the Result when new events are detected, but also handlers will be called when some error in the underlying event detection mechanism is detected.