### PR TITLE
fix(nonce): indentation mistake after last merge

### DIFF
--- a/ethers/signer.nim
+++ b/ethers/signer.nim
@@ -139,7 +139,7 @@ method populateTransaction*(
     if transaction.gasLimit.isNone:
       populated.gasLimit = some(await signer.estimateGas(populated, BlockTag.pending))
 
-  doAssert transaction.nonce.isSome, "nonce not populated!"
+  doAssert populated.nonce.isSome, "nonce not populated!"
 
   return populated
 

--- a/ethers/signer.nim
+++ b/ethers/signer.nim
@@ -119,18 +119,18 @@ method populateTransaction*(
   if transaction.gasPrice.isNone and (transaction.maxFee.isNone or transaction.maxPriorityFee.isNone):
     populated.gasPrice = some(await signer.getGasPrice())
 
-    if transaction.nonce.isNone and transaction.gasLimit.isNone:
-      # when both nonce and gasLimit are not populated, we must ensure getNonce is
-      # followed by an estimateGas so we can determine if there was an error. If
-      # there is an error, the nonce must be decreased to prevent nonce gaps and
-      # stuck transactions
-      populated.nonce = some(await signer.getNonce())
-      try:
-        populated.gasLimit = some(await signer.estimateGas(populated, BlockTag.pending))
-      except EstimateGasError as e:
-        raise e
-      except ProviderError as e:
-        raiseSignerError(e.msg)
+  if transaction.nonce.isNone and transaction.gasLimit.isNone:
+    # when both nonce and gasLimit are not populated, we must ensure getNonce is
+    # followed by an estimateGas so we can determine if there was an error. If
+    # there is an error, the nonce must be decreased to prevent nonce gaps and
+    # stuck transactions
+    populated.nonce = some(await signer.getNonce())
+    try:
+      populated.gasLimit = some(await signer.estimateGas(populated, BlockTag.pending))
+    except EstimateGasError as e:
+      raise e
+    except ProviderError as e:
+      raiseSignerError(e.msg)
 
   else:
     if transaction.nonce.isNone:

--- a/ethers/signer.nim
+++ b/ethers/signer.nim
@@ -139,6 +139,8 @@ method populateTransaction*(
     if transaction.gasLimit.isNone:
       populated.gasLimit = some(await signer.estimateGas(populated, BlockTag.pending))
 
+  doAssert transaction.nonce.isSome, "nonce not populated!"
+
   return populated
 
 method cancelTransaction*(


### PR DESCRIPTION
Must have been a rebase error...

But this would possibly explain a logic branch that would allow for a missing nonce.

An assertion has been added to ensure that a populated transaction always has a populated nonce.