### PR TITLE
Fix http subscription polling

### DIFF
--- a/ethers/provider.nim
+++ b/ethers/provider.nim
@@ -240,11 +240,15 @@ proc confirm*(
   var blockNumber: UInt256
   let blockEvent = newAsyncEvent()
 
-  proc updateBlockNumber {.async: (raises: [ProviderError]).} =
-    let number = await tx.provider.getBlockNumber()
-    if number > blockNumber:
-      blockNumber = number
-      blockEvent.fire()
+  proc updateBlockNumber {.async: (raises: []).} =
+    try:
+      let number = await tx.provider.getBlockNumber()
+      if number > blockNumber:
+        blockNumber = number
+        blockEvent.fire()
+    except ProviderError:
+      # there's nothing we can do here
+      discard
 
   proc onBlock(_: Block) =
     # ignore block parameter; hardhat may call this with pending blocks

--- a/ethers/providers/jsonrpc/subscriptions.nim
+++ b/ethers/providers/jsonrpc/subscriptions.nim
@@ -1,6 +1,5 @@
 import std/tables
 import std/sequtils
-import std/strutils
 import pkg/chronos
 import pkg/json_rpc/rpcclient
 import pkg/serde
@@ -9,7 +8,6 @@ import ../../provider
 include ../../nimshims/hashes
 import ./rpccalls
 import ./conversions
-import ./looping
 
 export serde
 

--- a/nim.cfg
+++ b/nim.cfg
@@ -1,3 +1,4 @@
 -d:"chronicles_log_level=INFO"
 -d:"json_rpc_websocket_package=websock"
 --warning[LockLevel]:off
+--warning[DotLikeOps]:off

--- a/testmodule/config.nims
+++ b/testmodule/config.nims
@@ -3,3 +3,5 @@ when (NimMajor, NimMinor) >= (1, 4):
   switch("hint", "XCannotRaiseY:off")
 when (NimMajor, NimMinor, NimPatch) >= (1, 6, 11):
   switch("warning", "BareExcept:off")
+
+--define:"chronicles_enabled:off"

--- a/testmodule/providers/jsonrpc/rpc_mock.nim
+++ b/testmodule/providers/jsonrpc/rpc_mock.nim
@@ -2,7 +2,6 @@ import ../../examples
 import ../../../ethers/provider
 import ../../../ethers/providers/jsonrpc/conversions
 
-import std/tables
 import std/sequtils
 import pkg/stew/byteutils
 import pkg/json_rpc/rpcserver except `%`, `%*`

--- a/testmodule/providers/jsonrpc/testJsonRpcProvider.nim
+++ b/testmodule/providers/jsonrpc/testJsonRpcProvider.nim
@@ -68,13 +68,13 @@ for url in ["ws://" & providerUrl, "http://"  & providerUrl]:
       check UInt256.fromHex("0x" & txResp.hash.toHex) > 0
 
     test "can wait for a transaction to be confirmed":
-      for confirmations in 0..3:
+      for confirmations in 1..3:
         let signer = provider.getSigner()
         let transaction = Transaction.example
         let populated = await signer.populateTransaction(transaction)
         let confirming = signer.sendTransaction(populated).confirm(confirmations)
         await sleepAsync(100.millis) # wait for tx to be mined
-        await provider.mineBlocks(confirmations - 1)
+        await provider.mineBlocks(confirmations)
         let receipt = await confirming
         check receipt.blockNumber.isSome
 

--- a/testmodule/testContracts.nim
+++ b/testmodule/testContracts.nim
@@ -305,8 +305,8 @@ for url in ["ws://"  & providerUrl, "http://"  & providerUrl]:
         executeTx(),
         executeTx()
       )
-      let receipt1 = await futs[1].confirm(0)
-      let receipt2 = await futs[2].confirm(0)
+      let receipt1 = await futs[1].confirm(1)
+      let receipt2 = await futs[2].confirm(1)
 
       check receipt1.status == TransactionStatus.Success
       check receipt2.status == TransactionStatus.Success

--- a/testmodule/testCustomErrors.nim
+++ b/testmodule/testCustomErrors.nim
@@ -136,7 +136,7 @@ suite "Contract custom errors":
 
     let contract = contract.connect(provider.getSigner())
     try:
-      let future = contract.revertsTransaction(overrides = overrides).confirm(0)
+      let future = contract.revertsTransaction(overrides = overrides).confirm(1)
       await sleepAsync(100.millis) # wait for transaction to be submitted
       discard await provider.send("evm_mine", @[]) # mine the transaction
       discard await future # wait for confirmation


### PR DESCRIPTION
Solves several issues with polling.

Includes 2 fixes in http subscription polling:
- resubscribe when a JSON RPC error is encountered, instead of looking for the string "filter not found" in the error message, because different nodes can have different error messages
- ensure that the polling loop cannot crash, by explicitly annotating the function signatures with allowed errors, and by using `asyncSpawn`

Includes 2 fixes in transaction confirmation:
- no longer allow `.confirm(0)`, because it doesn't wait for any blocks to be mined, not even the block that includes the transaction
- no longer rely on the block number that is reported in the newBlock filter callback, because hardhat is known to report pending blocks there