### PR TITLE
chore: updates non-versioned deps to their versioned counterparts

### DIFF
--- a/ethers.nimble
+++ b/ethers.nimble
@@ -1,4 +1,4 @@
-version = "0.10.0"
+version = "0.10.1"
 author = "Nim Ethers Authors"
 description = "library for interacting with Ethereum"
 license = "MIT"
@@ -10,9 +10,9 @@ requires "contractabi >= 0.6.0 & < 0.7.0"
 requires "questionable >= 0.10.2 & < 0.11.0"
 requires "https://github.com/codex-storage/nim-json-rpc >= 0.5.0 & < 0.6.0"
 requires "serde >= 1.2.1 & < 1.3.0"
-requires "stint"
-requires "stew"
-requires "eth#c482b4c5b658a77cc96b49d4a397aa6d98472ac7"
+requires "https://github.com/codex-storage/nim-stint-versioned >= 1.0.0 & < 2.0.0"
+requires "https://github.com/codex-storage/nim-stew-versioned >= 1.0.0 & < 2.0.0"
+requires "https://github.com/codex-storage/nim-eth-versioned >= 1.0.0 & < 2.0.0"
 
 task test, "Run the test suite":
   # exec "nimble install -d -y"


### PR DESCRIPTION
Also bumps ethers patch version