### PR TITLE
Fix/http-unsibscribe-2

### DIFF
--- a/ethers/providers/jsonrpc/subscriptions.nim
+++ b/ethers/providers/jsonrpc/subscriptions.nim
@@ -285,15 +285,16 @@ method unsubscribe*(subscriptions: PollingSubscriptions,
                   {.async.} =
   subscriptions.logFilters.del(id)
   subscriptions.callbacks.del(id)
-  let sub = subscriptions.subscriptionMapping[id]
-  subscriptions.subscriptionMapping.del(id)
-  try:
-    discard await subscriptions.client.eth_uninstallFilter(sub)
-  except CancelledError as e:
-    raise e
-  except CatchableError:
-    # Ignore if uninstallation of the filter fails. If it's the last step in our
-    # cleanup, then filter changes for this filter will no longer be polled so
-    # if the filter continues to live on in geth for whatever reason then it
-    # doesn't matter.
-    discard
+  if subscriptions.subscriptionMapping.hasKey(id):
+    let sub = subscriptions.subscriptionMapping[id]
+    subscriptions.subscriptionMapping.del(id)
+    try:
+      discard await subscriptions.client.eth_uninstallFilter(sub)
+    except CancelledError as e:
+      raise e
+    except CatchableError:
+      # Ignore if uninstallation of the filter fails. If it's the last step in our
+      # cleanup, then filter changes for this filter will no longer be polled so
+      # if the filter continues to live on in geth for whatever reason then it
+      # doesn't matter.
+      discard

--- a/ethers/providers/jsonrpc/subscriptions.nim
+++ b/ethers/providers/jsonrpc/subscriptions.nim
@@ -283,18 +283,17 @@ method subscribeLogs(subscriptions: PollingSubscriptions,
 method unsubscribe*(subscriptions: PollingSubscriptions,
                    id: JsonNode)
                   {.async.} =
-  subscriptions.logFilters.del(id)
-  subscriptions.callbacks.del(id)
-  if subscriptions.subscriptionMapping.hasKey(id):
-    let sub = subscriptions.subscriptionMapping[id]
-    subscriptions.subscriptionMapping.del(id)
-    try:
+  try:
+    subscriptions.logFilters.del(id)
+    subscriptions.callbacks.del(id)
+    if sub =? subscriptions.subscriptionMapping.?[id]:
+      subscriptions.subscriptionMapping.del(id)
       discard await subscriptions.client.eth_uninstallFilter(sub)
-    except CancelledError as e:
-      raise e
-    except CatchableError:
-      # Ignore if uninstallation of the filter fails. If it's the last step in our
-      # cleanup, then filter changes for this filter will no longer be polled so
-      # if the filter continues to live on in geth for whatever reason then it
-      # doesn't matter.
-      discard
+  except CancelledError as e:
+    raise e
+  except CatchableError:
+    # Ignore if uninstallation of the filter fails. If it's the last step in our
+    # cleanup, then filter changes for this filter will no longer be polled so
+    # if the filter continues to live on in geth for whatever reason then it
+    # doesn't matter.
+    discard

--- a/testmodule/providers/jsonrpc/testJsonRpcSubscriptions.nim
+++ b/testmodule/providers/jsonrpc/testJsonRpcSubscriptions.nim
@@ -49,6 +49,15 @@ template subscriptionTests(subscriptions, client) =
     discard await client.call("evm_mine", newJArray())
     await sleepAsync(100.millis)
     check count == 0
+  
+  test "unsubscribing from a non-existent subscription does not do any harm":
+    await subscriptions.unsubscribe(newJInt(0))
+  
+  test "duplicate unsubscribe is harmless":
+    proc callback(blck: Block) = discard
+    let subscription = await subscriptions.subscribeBlocks(callback)
+    await subscriptions.unsubscribe(subscription)
+    await subscriptions.unsubscribe(subscription)
 
   test "stops listening to new blocks when provider is closed":
     var count = 0

--- a/testmodule/providers/jsonrpc/testJsonRpcSubscriptions.nim
+++ b/testmodule/providers/jsonrpc/testJsonRpcSubscriptions.nim
@@ -54,7 +54,7 @@ template subscriptionTests(subscriptions, client) =
     await subscriptions.unsubscribe(newJInt(0))
   
   test "duplicate unsubscribe is harmless":
-    proc callback(blck: Block) = discard
+    proc callback(blck: ?!Block) = discard
     let subscription = await subscriptions.subscribeBlocks(callback)
     await subscriptions.unsubscribe(subscription)
     await subscriptions.unsubscribe(subscription)


### PR DESCRIPTION
> There was a cross mergin issue and we had to revert. That's why a separate PR.
> The original PR has been approved so here I am merging it directly without review.

Unsubscribing from a non-existent subscription as well as duplicate unsubscribe should have no effect (harmless).