### PR TITLE
fix(ci): re-add 1.6.20 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        nim: [2.0.14]
+        nim: [1.6.20, 2.0.14]
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/ethers.nimble
+++ b/ethers.nimble
@@ -3,7 +3,7 @@ author = "Nim Ethers Authors"
 description = "library for interacting with Ethereum"
 license = "MIT"
 
-requires "nim >= 2.0.14"
+requires "nim >= 1.6.20"
 requires "chronicles >= 0.10.3 & < 0.11.0"
 requires "chronos >= 4.0.4 & < 4.1.0"
 requires "contractabi >= 0.7.0 & < 0.8.0"


### PR DESCRIPTION
No need to drop it, yet...

The other alternative is to drop support of 1.6.x and bump a major version (2.0.0).