### PR TITLE
chore: re-activate styleCheck

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -1,8 +1,5 @@
 --styleCheck:usages
-# Disable styleCheck temporarily because Nim 2.x is checking that 
-# getopt is used instead of  
-# https://github.com/status-im/nim-testutils/pull/54/commits/a1b07a11dd6a0c537a72e5ebf70df438c80f920a
-#--styleCheck:error
+--styleCheck:error
 
 # begin Nimble config (version 1)
 when fileExists("nimble.paths"):


### PR DESCRIPTION
With [testutils 0.6.0](https://github.com/status-im/nim-testutils/commit/94d68e796c045d5b37cabc6be32d7bfa168f8857) released, we can re-active the style checking (see https://github.com/status-im/nim-testutils/pull/54). 