### PR TITLE
chore: add log scope for signer

### DIFF
--- a/ethers/signer.nim
+++ b/ethers/signer.nim
@@ -13,6 +13,9 @@ type
   Signer* = ref object of RootObj
     populateLock: AsyncLock
 
+logScope:
+  topics = "ethers signer"
+
 template raiseSignerError*(message: string, parent: ref CatchableError = nil) =
   raise newException(SignerError, message, parent)
 


### PR DESCRIPTION
This PR introduces a dedicated log scope for the signer, following a suggestion from @benbierens, as `EIP-1559` logs tend to be quite frequent.
